### PR TITLE
Solved: [자료구조] BOJ_덱 홍지우

### DIFF
--- a/자료구조/지우/BOJ_10866_덱.cpp
+++ b/자료구조/지우/BOJ_10866_덱.cpp
@@ -1,0 +1,53 @@
+#include <iostream>
+#include <deque>
+
+using namespace std;
+
+int main() {
+    cin.tie(NULL);
+    
+    int N;
+    cin >> N;
+    
+    // queue<int> q; // 와 큐는 push_back(), pop_back()이 안 먹네
+    deque<int> dq; // 모든 입구에서 삽입 삭제 ㄱㄴ (큐+스택)
+    
+    for(int i=0; i<N; i++) {
+        string s; int num;
+        cin >> s;
+        
+        if(s=="push_back") {
+            cin >> num;
+            dq.push_back(num);
+        } else if(s == "push_front") {
+            cin >> num;
+            dq.push_front(num);
+        } else if(s == "pop_front") {
+            if(dq.empty()) {
+                cout << -1 << "\n";
+            } else {
+                cout << dq.front() << "\n"; 
+                dq.pop_front();
+            }
+        } else if(s == "pop_back") {
+            if(dq.empty()) {
+                cout << -1 << "\n";
+            } else {
+                cout << dq.back() << "\n"; 
+                dq.pop_back();
+            }        
+        } else if(s == "size") {
+            cout << dq.size() << "\n";
+        } else if(s == "empty") {
+            if(dq.empty()) cout << 1 << "\n";
+            else cout << 0 << "\n";
+        } else if(s == "front") {
+            if(dq.empty()) cout << -1 << "\n";
+            else cout << dq.front() << "\n";
+        } else if(s == "back") {
+            if(dq.empty()) cout << -1 << "\n";
+            else cout << dq.back() << "\n";
+        } 
+    }
+    
+}


### PR DESCRIPTION
### 자료구조
- 덱

### 시간복잡도
```
push_front, push_back → O(1)
pop_front, pop_back → O(1)
size, empty, front, back → O(1)
```
- std::deque는 양쪽 끝에서 삽입/삭제 모두 O(1) 시간에 작동함.
- 명령어 수는 최대 N번 반복 → 전체 시간복잡도는 O(N)

### 배운점
- std::vector로 `pop_front()`나 `push_front()`를 했더라면 O(N) 시간이 걸려 성능이 떨어진다.
    - 반대로, vector를 `v[i]` 접근 빠름, 데이터 정렬/검색(`sort`, `binary_search`, `lower_bound` 등)에 유리하다.
- c++ 큐는 어느정도 덱의 성질을 갖고 있는 것으로 알았으나, 모든 입구에서 삽입 삭제가 가능하지 않다. - push, pop의 옵션이 없음
- 덱은 스택 + 큐의 특성 종합체로 모든 입구에서 삽입/삭제가 잦을 때 사용한다.
