### PR TITLE
Solved: [그래프 탐색] BOJ_바이러스 김나영

### DIFF
--- a/그래프 탐색/나영/BOJ_2606_바이러스.java
+++ b/그래프 탐색/나영/BOJ_2606_바이러스.java
@@ -1,0 +1,46 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static int n, m, ans;
+    static StringBuilder sb = new StringBuilder();
+    static List<List<Integer>> arr;
+    static StringTokenizer st;
+    static boolean [] visited;
+    public static void main(String[] args) throws IOException {
+        n = Integer.parseInt(br.readLine());
+        m = Integer.parseInt(br.readLine());
+
+        arr = new ArrayList<>();
+        for (int i = 1; i <= n+1; i++) {
+            arr.add(new ArrayList<>());
+        }
+        
+        visited = new boolean [n+1];
+
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            arr.get(a).add(b);
+            arr.get(b).add(a);
+        }
+
+        find(1);
+        
+        System.out.println(ans);
+    }
+
+    static void find(int c) {
+        visited[c] = true;
+        for (Integer i : arr.get(c)) {
+            if(visited[i]) continue;
+            ans++;
+            find(i);
+        }
+    }
+}


### PR DESCRIPTION
### 자료구조
- List

### 알고리즘
- 구현

### 시간복잡도
- 그래프 구성 -> O(m)
- DFS 탐색 -> O(n)
- 최종 시간복잡도 : O(n + m)

### 배운점
- 원래 List<Integer> [n+1] 이렇게 배열로 받고 싶었는데 가능은 하지만 
    - Java는 제네릭 타입 배열 직접 생성 불가
    - Java에서는 컴파일 이후에는 제네릭 타입 정보가 모두 사라지기 때문이다. 이걸 **타입 소거(Type Erasure)**라고 한다.
```
List<String>[] arr = new ArrayList[10];
arr[0] = new ArrayList<Integer>();  // ❗ 이런 일이 가능해짐
arr[0].add(123); // int 값을 넣음
String s = arr[0].get(0); // ❌ 런타임 에러 (ClassCastException)
```
- 이러한 문제로 그냥 List<List<Integer>>의 형식으로 풀었다