### PR TITLE
Solved: [구현] BOJ_달력 홍지우

### DIFF
--- a/구현/지우/BOJ_20207_달력.cpp
+++ b/구현/지우/BOJ_20207_달력.cpp
@@ -1,0 +1,45 @@
+#include <iostream>
+#include <vector>
+#include <cmath>
+
+using namespace std;
+
+vector<int> days;
+
+int main() {
+    days.resize(366);
+    int ans = 0; //면적
+
+    int N; cin >> N;
+    int minStart = 0; int maxEnd = 0;
+    for(int i=0; i<N; i++) {
+        int start; int end;
+        cin >> start >> end;
+        minStart = min(start, minStart);
+        maxEnd = max(end, maxEnd);
+
+        for(int j=start; j<=end; j++) { // 최대 1000 * 365
+            days[j]++;
+        }
+    }
+
+    int i=minStart;
+    while(i <= maxEnd && i <366) { // 최대 365
+        int dayCnt = 0; //연속된 날짜들
+        int maxSchedule = 0; // 1day에 제일 많이 쌓인 일정 수
+
+        while(days[i] > 0 && i <366) {
+            maxSchedule = max(days[i], maxSchedule);
+            dayCnt++;
+            i++;
+        }
+
+        ans += dayCnt * maxSchedule;
+
+        i++;
+    }
+
+    cout << ans;
+
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터

### 알고리즘
- 구현

### 시간복잡도
일정 입력 처리에서 각 구간마다 O(end - start + 1) 수행 → 전체는 O(N × D), 최악의 경우 N=1000, D=365.
이후 면적 계산 단계는 days[1~366]을 한 번 순회하므로 O(365) = O(1).
전체 시간복잡도는 O(N × D), 즉 **최악의 경우 O(365,000)**

### 배운 점
- 벡터 공간을 366으로 딱 알맞게 뒀다 (각 칸이 날짜를 의미하게) 
- 중간에 벡터[366]을 접근할 수 있다(while문 i++가 되면서) \ 이때 **지정 안한 공간에서 0이 아닌 엄청 큰 수가 나온다.** - 사실 지정 안 한 공간을 접근하는 것 자체가 문제긴 함
- 벡터[366] = 0으로 해두던가 아님 while(days[i] > 0 && i <366) { <- 이렇게 해줌으로써 해당 상황을 방지할 수 있다.

난 아직 c++이 미흡한 듯.. 헤헷

- 풀이방법
    - 등장하는 날짜를 카운트배열로 채웠다 (1-2일 days[1]++; days[2]++;)
    - 일정이 겹치면 카운트배열은 증가한다.
    - 0이 되기 전까지의 배열의 수(dayCnt) * 카운트배열 속 일정이 제일 많이 겹친 날(maxSchedule) 을 더해가면서  다 끝나면 최종값을 반환하면 된다.