### PR TITLE
Solved: [구현] BOJ_zoac 김나영

### DIFF
--- a/구현/나영/BOJ_16719_zoac.java
+++ b/구현/나영/BOJ_16719_zoac.java
@@ -1,0 +1,49 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static Scanner sc = new Scanner(System.in);
+    static char [] charn;
+    static boolean [] visited;
+    static String input;
+    static char tmp;
+    static int index, size, cnt;
+    static StringBuilder sb2 = new StringBuilder();
+    public static void main(String[] args) {
+        input = sc.next();
+        charn = input.toCharArray();
+        size = input.length();
+        visited = new boolean [charn.length];
+
+        find(0);
+
+        System.out.println(sb2.toString());
+    }
+
+    static void find(int n) {
+        int cnt = 0;
+
+        while (true) {
+            tmp = 'Z' + 1;
+            cnt = 0;
+            for (int i = n; i < input.length(); i++) {
+                if (!visited[i] && input.charAt(i) < tmp) {
+                    tmp = input.charAt(i);
+                    index = i;
+                }
+            }
+            if (tmp > 'Z') break;
+            visited[index] = true;
+            for (int i = 0; i < visited.length; i++) {
+                if (visited[i]) {
+                    sb2.append(charn[i]);
+                    if (i >= n) cnt++;
+                }
+            }
+            sb2.append("\n");
+            if (cnt >= charn.length - n) break;
+            find(index);
+        }
+    }
+}


### PR DESCRIPTION
### 자료구조
- 배열

### 알고리즘
- 구현

### 시간복잡도
- find(0) 에서 0 ~ charn.length 까지 돌며 가장 사전순으로 앞에 있는 문자를 찾음 : O(N)
- visited 배열울 돌며 TRUE 인 값 출력 : O(N)
- find(index)로 가장 사전순 앞의 문자 인덱스를 기준으로 다시 시작
- find(index)에서 index ~ charn.length 까지 돌며,,, : O(N)
- 위 작업을 N번 반복
- 그래서 최종 시간복잡도는 O(N) * N = O(N^2)

### 배운점
- 진짜 인생 역대급 개막장구현
- 인덱스 0을 기준으로 charn 배열을 한 번 돌며 가장 작은 사전 순 문자를 찾고, visited 처리 후 find(index)로 해당 위치부터 charn 배열 끝까지 도는 로직을 설계
- 이 때 if (cnt >= charn.length - n) break; 해당 구문으로 index부터 문자열 마지막까지 전부 visited 되었다면 이제 이 인덱스부터는 탐색하지 않아도 됨. break 시킴
- 근데 여기서,, 예를 들어서 zoac의 경우 출력값이
```
A
AC
OAC
OAC
ZOAC
```
- 이렇게 나옴. 이유는 A에서 가질 수 있는 모든 문자열을 append 하면 다시 find(0)으로 돌아감. 이 때 O가 가장 사전 순 앞 글자이므로 visited 처리한 뒤 sb2에 append 하고, find(O의 인덱스) 재귀를 탐.
- 이 때 O는 이미 추가되었고, 그 다음 문자열들도 이미 다 visited 되었는데 find 재귀를 한 번 더 타면서 동일 결과가 출력됨
- 이를 방지하기 위해 if (tmp > 'Z') break 구문을 통해 tmp에 아무 값도 들어오지 않았다면 해당 구문 종료(죽고싶다)
- 미친 디버깅,,, 문제 한 번 더 풀어봐야 할 듯