### PR TITLE
Solved: [구현] BOJ_왕복 김나영

### DIFF
--- a/구현/나영/BOJ_18311_왕복.java
+++ b/구현/나영/BOJ_18311_왕복.java
@@ -1,0 +1,42 @@
+// 23:20
+
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static int n, run, cnt;
+    static long k;
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int [] arr;
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        k = Long.parseLong(st.nextToken());
+
+        arr = new int[n];
+
+        cnt = -1;
+        
+        st = new StringTokenizer(br.readLine());
+
+        for (int i = 0; i < n; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        if (k != 0) {
+            while (true) {
+                if (run == n-1 || run == 0) cnt = -cnt;
+                k -= arr[run];
+
+                if (run == n-1) k -= arr[run];
+                
+                if (k < 0) break;
+                run += cnt;
+            }
+        }
+        
+        System.out.println(run + 1);
+    }
+}


### PR DESCRIPTION
### 자료구조
- 배열

### 알고리즘
- 구현

### 시간복잡도
- O(n + k)
- n번 입력받고, 최대 k번 반복하여 남아있는 거리를 계산함(모든 arr의 인자가 1일 경우)

### 배운점
- 이해가 안 되는 점
    - 왜 k를 long 타입으로 바꾸니까 통과하는가,, => 알고 보니 k의 범위가 n(최대 100,000) * 50,000 = 5,000,000,000 즉 50억까지 갈 수 있다,,ㄷㄷ 문제 잘 읽자
- 3과 4 사이에 딱 도착했을 때, 즉 코스 3이 딱 끝나는 지점에서 다음 코스가 현재 내 코스임을 모르고 짰음. 헤헷
- 그냥 cnt로 계속 인덱스 돌면서 k의 각 코스의 거리를 빼다가 0보다 작아지는 시점의 인덱스 쪽 코스가 정답임.