### PR TITLE
Solved: [구현] BOJ_왕복 홍지우

### DIFF
--- a/구현/지우/BOJ_18311_왕복.cpp
+++ b/구현/지우/BOJ_18311_왕복.cpp
@@ -1,0 +1,44 @@
+#include <iostream>
+#include <vector>
+
+using namespace std;
+
+int main() {
+    int N; long K;
+    cin >> N >> K;
+
+    vector<int> v(N+1, 0);
+
+    for(int i=1; i<=N; i++) {
+        cin >> v[i];
+    }
+
+    int idx = 1;
+    bool isReturn = false;
+    while(1) {
+
+        long left = K - v[idx];
+        // cout << idx << "에서" << left << "\n";
+
+        if(left < 0) {
+            cout << idx;
+            break;
+        }
+
+        if(!isReturn) {
+            idx++;
+            if(idx > N) {
+                isReturn = true;
+                idx--;
+            }
+        } else {
+            idx--;
+        }
+
+        K = left;
+
+        
+    }
+    
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터

### 알고리즘
- 구현

### 시간복잡도
왕복은 최대 2N-1번 이동하며 각 칸마다 O(1) 연산 수행
최악의 경우 K가 매우 커도 각 칸에서 K를 줄이므로, 총 시간은 O(N)
전체 시간복잡도는 O(N), 공간복잡도는 O(N) (입력 배열 저장용)

### 배운 점
- 1차 풀이) K가 왕복이 가능할만큼 크다는 것을 간과하고 모든 거리마다 트랙 정보를 저장한 배열로 두고 풀려 했다.
    - 런타임에러 왜? K-(총 수-K) 하려고 했는데 이때 음수가 나오고 벡터[음수]로 접근할 가능성이 있음
    - 일단 안됨 -> 벡터 공간을 누적된 길이만큼 할당하는게 애초에 불가능하다..

- 2차 풀이) K에서 트랙의 길이만큼 빼가면서 해당 트랙을 지났을 때 '음수'가 되면 해당 트랙을 cout 한다.
    - isReturn bool변수를 관리하며 갈 때는 idx(트랙 몇 번째)++, 올 때는 idx-- 를 한다. 