### PR TITLE
Solved: [구현] BOJ_그룹 단어 체커 홍지우

### DIFF
--- a/구현/지우/BOJ_1316_그룹 단어 체커.cpp
+++ b/구현/지우/BOJ_1316_그룹 단어 체커.cpp
@@ -1,0 +1,44 @@
+#include <iostream>
+#include <set>
+
+using namespace std;
+
+int cnt;
+
+void isGroup(string input) {
+
+    set<char> s;
+
+    s.insert(input[0]);
+    
+    for(int i=1; i<input.length(); i++) {
+        // 
+        if(input[i-1] != input[i]) {
+            if(s.count(input[i])) {
+                // cout << "그룹 아님" << input[i-1] << " 현재 " << input[i] << "\n";
+                return;
+            }
+            s.insert(input[i]);
+        } else {
+            s.insert(input[i]); 
+        }
+    }
+    cnt ++;
+    return;
+}
+
+
+
+int main() {
+
+    int N; cin >> N;
+    cnt = 0;
+    for(int i=0; i<N; i++) {
+        string input; 
+        cin >> input;
+        isGroup(input);
+    }
+
+    cout << cnt;
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- set

### 알고리즘
- 구현

### 시간복잡도
- 문자열 하나당 최대 길이 L만큼 순회하며 set 삽입/탐색 (O(L log L))
- 총 N개의 문자열에 대해 반복하므로, 전체 시간복잡도는 O(N * L log L)

### 배운 점
- 만약 그룹 단어가 아니라면 중간에 return 시켜야 하므로 메서드로 구현함
- 이전 단어와 다르다! <- 새로운 단어 OR 그룹 단어 깨는 단어
    - set에 원래 있던 친구? 그룹 단어 깨졌다! return(cnt에 추가 안됨)
    - set에 없었음? 새로운 단어다! set에 넣어주자!!
- 다 풀어놓고 cnt 위치, set 위치 잘못 넣어두고 으잉 뭐지? 함 .. (제 발..)