### PR TITLE
Solved : [구현] BOJ_그룹 단어 체커 김나영

### DIFF
--- a/구현/나영/BOJ_1316_그룹 단어 체커.java
+++ b/구현/나영/BOJ_1316_그룹 단어 체커.java
@@ -1,0 +1,49 @@
+// 20분 소요
+
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static Scanner sc = new Scanner(System.in);
+    static int n, ans;
+    static char [] charn;
+    // static List<Integer> list = new ArrayList<>();
+    static boolean isS;
+    static Set<Character> set;
+    public static void main(String[] args) {
+        n = sc.nextInt();
+        for (int i = 0; i < n; i++) {
+            // isS 초기화
+            isS = true;
+
+            // set 초기화
+            set = new HashSet<>();
+            
+            // 단어를 char 배열로 받음
+            charn = sc.next().toCharArray();
+
+            // list에 중복되지 않고 순서대로 있는 단어를 저장
+            // for (int j = 0; j < charn.length; j++) {
+            //     if (charn) 
+            // }
+
+            /* 단어 처음부터 돌며 
+            특정 char가 더 이상 나오지 않으면 다음 char로 넘어감.
+            이 때, 넘어간 char가 set에 있는지 확인하고 있으면 그룹 단어가 아니므로 break
+            */
+            for (int j = 0; j < charn.length; j++) {
+                char c = charn[j];
+                if (set.contains(c)) {
+                    isS = false;
+                    break;
+                } else {
+                    set.add(c);
+                    while (j+1 < charn.length && c == charn[j+1]) j++;
+                }
+            }
+            if (isS) ans++;
+        }
+        System.out.println(ans);
+    }
+}


### PR DESCRIPTION
### 자료구조
- 배열
- Set

### 알고리즘
- 구현

### 시간복잡도
![image](https://github.com/user-attachments/assets/d382f24d-74a1-4d48-983c-d1304af1b1e2)
- 단어가 n번 반복 * charn 배열 안의 문자열 탐색
    - 이 때, 같은 문자이면 j++로 패스하므로 사실상 **한 문자당 한 번씩만 탐색함**

### 배운점
- 근데 나 너무 같은 방식으로만 푸는 듯,, 맨날 while 문 때리는 거 같다. 이건 overdoes.
- 그래서 받은 문자열을 한 번 돌면서 새로운 알파벳 나타나면 list에 저장해 한 알파벳 당 한 번만 저장한 뒤 돌릴까 했는데 그럼 문자열 한 번 돌고 또 list도 도는 거라 의미가 없다고 판단했음.
- 그래서 charn 배열을 돌면서 새로운 알파벳이 나타나면 set에 contains 되었는지 확인 후 없으면 add하고 새로운 알파벳이 나오기 전까지 j++함.
- 심플한 문제인데 다른 사람이 어떤 방식으로 푸는 지 보는 게 좋을 듯