### PR TITLE
Solved: [그래프 탐색] PG_게임 맵 최단거리 홍지우

### DIFF
--- a/그래프 탐색/지우/PG_게임 맵 최단거리.cpp
+++ b/그래프 탐색/지우/PG_게임 맵 최단거리.cpp
@@ -1,0 +1,62 @@
+#include <vector>
+#include <queue>
+#include <iostream>
+
+using namespace std;
+
+int N; int M;
+vector<vector<int> > arr;
+vector<vector<int>> dist;
+
+int dr[] = {1,0,-1,0};
+int dc[] = {0,1,0,-1};
+
+bool inRange(int r, int c) {
+    return r>=0 && r<N && c>=0 && c<M;
+}
+ 
+int bfs() {
+    queue<pair<int,int>> q;
+    pair<int, int> start = {0,0};
+    q.push(start);
+    dist[0][0] = 1;
+    
+    
+    while(!q.empty()) {
+        pair<int, int> pos = q.front(); q.pop();
+        
+        int r = pos.first;
+        int c = pos.second;
+        
+        // cout << r << " " << c << "\n";
+
+        if(r == N-1 && c == M-1) {
+            return dist[r][c];
+        }
+
+        for(int d=0; d<4; d++) {
+            int nr = r+dr[d];
+            int nc = c+dc[d];
+            if(inRange(nr,nc) && dist[nr][nc] == 0 && arr[nr][nc] == 1) {
+                dist[nr][nc] = dist[r][c]+1;
+                
+                pair<int, int> nxtPos = {nr, nc};
+                q.push(nxtPos);
+            }
+        }
+    }
+    
+    return -1;
+    
+    
+}
+
+int solution(vector<vector<int> > maps)
+{
+    int answer = 0;
+    arr = maps; N = maps.size(); M = maps[0].size();
+    dist.resize(N, vector<int>(M,0));
+    
+    answer = bfs();
+    return answer;
+}


### PR DESCRIPTION
### 자료구조
- 벡터

### 알고리즘
- BFS

### 시간복잡도
BFS는 각 칸을 최대 한 번씩 방문하므로, 전체 칸 수인 N * M 만큼 동작합니다.
각 칸마다 최대 4방향(상하좌우)을 검사하지만, 이 역시 총합은 O(N * M)에 포함됩니다.
따라서 전체 시간복잡도는 **O(N × M)**입니다.

### 배운 점
- 이런 문제 너무 오랜만에 풀어봄..
- cnt로 두고 돌리려고 했는데 visited 전에 cnt++을 했더니 그냥 방문한 곳의 횟수만 더해간다.
    - SOL: dist[][]에 거리를 담아두고 `dist[nr][nc] = dist[r][c]++;` 온 곳에서의 거리에서 더한다.
    - visited 배열도 dist로 대체해서 이미 값이 채워졌으면 가지 않는 것으로 설정했다.

