### PR TITLE
Solved: [구현] BOJ_아이템 줍기 홍지우

### DIFF
--- a/그래프 탐색/지우/PG_아이템 줍기.cpp
+++ b/그래프 탐색/지우/PG_아이템 줍기.cpp
@@ -1,0 +1,65 @@
+#include <string>
+#include <vector>
+#include <iostream>
+#include <queue>
+
+using namespace std;
+
+int dr[] = {1,0,-1,0};
+int dc[] = {0,1,0,-1};
+
+bool inRange(int r, int c) {
+    return r>=0 && r<101 && c>=0 && c<101;
+}
+
+int solution(vector<vector<int>> rectangle, int characterX, int characterY, int itemX, int itemY) {
+    int answer = 0;
+    vector<vector<int>> maps(101,vector<int>(101,0));
+    
+    for(int i=0; i<rectangle.size(); i++) {
+        int sr = rectangle[i][0]*2; int sc = rectangle[i][1]*2; 
+        int er = rectangle[i][2]*2; int ec = rectangle[i][3]*2;
+        
+        for(int r=sr; r<=er; r++) {
+            for(int c=sc; c<=ec; c++) {
+                maps[r][c] = 1;
+            }
+        }
+    }
+    
+    for(int i=0; i<rectangle.size(); i++) {
+        int sr = rectangle[i][0]*2; int sc = rectangle[i][1]*2; 
+        int er = rectangle[i][2]*2; int ec = rectangle[i][3]*2;
+        
+        for(int r=sr+1; r<er; r++) {
+            for(int c=sc+1; c<ec; c++) {
+                maps[r][c] = 0; // 안에 비우기 
+            }
+        }
+    }
+    
+    queue<pair<int,int>> q;
+    vector<vector<int>> dist(101,vector<int>(101,0));
+    q.push({characterX*2,characterY*2});
+    dist[characterX*2][characterY*2] = 1;
+    
+    while(!q.empty()) {
+        pair<int,int> pos = q.front(); q.pop();
+        int r = pos.first;
+        int c = pos.second;
+        
+        if(r == itemX*2 && c == itemY*2) break;
+        
+        for(int d=0; d<4; d++) {
+            int nr = r+dr[d];
+            int nc = c+dc[d];
+            
+            if(inRange(nr, nc) && dist[nr][nc] == 0 && maps[nr][nc] == 1) {
+                dist[nr][nc] = dist[r][c]+1;
+                q.push({nr,nc});
+            }
+        }
+    }
+    
+     return dist[itemX*2][itemY*2]/2; //좌표 2배 확장했기에 줄이기
+}


### PR DESCRIPTION
### 자료구조
- 벡터
- 큐

### 알고리즘
- BFS

### 시간복잡도
사각형 그리기 및 내부 비우기: 최대 10개 * 100×100 = O(1)
BFS 탐색: 200×200 그리드에서 각 칸 1회 방문 → O(1)

### 배운 점
- 좌표를 다루는 문제 - 좌표값을 표현하기 위해 현재x,y * 2를 한다.
    ![image](https://github.com/user-attachments/assets/17f7103c-f505-4619-bdca-217276703183)
    - 좌표 상으로는 (3,5) (3,6)이 한 칸을 띄우고 있지만 배열상으로는 티가 나지 않는다. 그저 이어있다고 보인다.
    - 이를 막기 위해 모든 값을 2배로 하면 10 -'11' - 12가 되면서 한 칸 건너 표시된다. 
- 어떻게 테두리만 구하지?
    - 모두 채우고
    - 그 사이값을 모두 0으로 비워준다.
- 좌표*2 하면서 거리값이 모두 2배가 되었다 -> /2를 하여 출력해준다.