### PR TITLE
Solved: [그래프 탐색] BOJ_DFS와 BFS 홍지우

### DIFF
--- a/그래프 탐색/지우/BOJ_1260_DFS와BFS.cpp
+++ b/그래프 탐색/지우/BOJ_1260_DFS와BFS.cpp
@@ -1,0 +1,77 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+
+using namespace std;
+
+int N;
+vector<vector<int>> adj;
+vector<int> visDfs;
+vector<int> visBfs;
+
+string dfsAns;
+string bfsAns;
+
+void dfs(int v) {
+    visDfs[v] = true;
+    dfsAns += to_string(v) + " ";
+
+    for(auto nxt : adj[v]) {
+        if(!visDfs[nxt]) {
+            dfs(nxt);
+        }
+    }
+}
+
+void bfs(int v) {
+    queue<int> q;
+    visBfs[v] = true;
+    q.push(v);
+
+    while(!q.empty()) {
+        int curr = q.front(); q.pop();
+        bfsAns += to_string(curr) + " ";
+
+        for(auto nxt : adj[curr]) {
+            if(!visBfs[nxt]) {
+                visBfs[nxt] = true;
+                q.push(nxt);
+            }
+        }
+    }
+    
+}
+
+
+int main() {
+    int M; int V;
+    cin >> N >> M >> V;
+    adj.resize(N+1, vector<int>(0,0));
+    visDfs.resize(N+1, false);
+    visBfs.resize(N+1, false);
+
+    for(int i=0; i<M; i++) {
+        int a; int b;
+        cin >> a >> b;
+        adj[a].push_back(b);
+        adj[b].push_back(a);
+    }
+
+    for(int i=1; i<=N; i++) {
+        sort(adj[i].begin(), adj[i].end());
+    }
+
+    // dfs
+    visDfs[V] = true;
+    dfsAns = "";
+    dfs(V);
+
+    // bfs
+    bfsAns = "";
+    bfs(V);
+
+    cout << dfsAns << "\n" << bfsAns;
+    
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터
- 큐(BFS용)

### 알고리즘
- 그래프탐색(DFS, BFS)

### 시간복잡도
  - **그래프 입력 및 정렬:**
  O(M + N log N)
  (정점별 인접 리스트 정렬 포함)
  
  - **DFS 및 BFS 탐색:**
  각각 O(N + M)
  (정점과 간선을 한 번씩 방문)
  
  - **총 시간복잡도:**
  O(N + M + N log N)
  (정렬 포함 전체 시간)

### 배운 점
-  방문할 수 있는 정점이 여러 개인 경우에는 정점 번호가 작은 것을 먼저 방문
    - 각 정점에 대한 인접리스트를 sort해서 사용함 
- DFS
    - for문을 돌리면 어차피 끝이 있기 때문에 기저조건을 달아주지 않아도 된다.
    - 이 문제의 경우, 가장 '첫' 답을 인출하면 됐기 때문에 visDfs[] = false로 문을 닫진 않았다. 
    - DFS는 늘 전역변수를 바로 활용할 수 있다. 다음 친구를 바로 true로 처리하고 답에 연결했다.
- BFS
    -  늘 푸는 공식대로 풀었음