### PR TITLE
Solved: [구현] BOJ_소가 정보섬에 올라온 이유 홍지우

### DIFF
--- a/구현/지우/BOJ_17128_소가 정보섬에 올라온 이유.cpp
+++ b/구현/지우/BOJ_17128_소가 정보섬에 올라온 이유.cpp
@@ -1,0 +1,64 @@
+#include <iostream>
+#include <vector>
+
+using namespace std;
+
+vector<int> cows;
+vector<int> scopes; // 범위별(시작점 기준) - 곱한 값
+vector<vector<int>> whatScopes; // 번호별 - 각 어떤 범위에 있는지 
+int N; int Q;
+
+void mulnSum() {
+
+    for(int i=1; i<=N; i++) {
+        int idx = i; int scopeScore = 1; int cnt = 0;
+        while(cnt < 4) {
+            scopeScore *= cows[idx];
+            whatScopes[idx].push_back(i);
+            idx = (idx+1)%(N+1);
+            if(idx == 0) idx = 1;
+            
+            cnt++;
+        }
+        scopes[i] = scopeScore;
+    }
+
+    return;
+}
+
+int sumAll() {
+    int ans = 0;
+    for(int i=1; i<=N; i++) {
+        ans += scopes[i];
+    }
+    return ans;
+}
+
+int main() {
+    cin.tie(0);
+    ios::sync_with_stdio(0);
+
+    cin >> N >> Q;
+    cows.resize(N+1, 0); scopes.resize(N+1, 0); 
+    whatScopes.resize(N+1, vector<int>(0,0));
+    for(int i=1; i<=N; i++){
+        cin >> cows[i];
+    }
+
+    mulnSum();
+    int total = sumAll();
+
+    for(int i=0; i<Q; i++) {
+        int q; cin >> q;
+        for(auto change : whatScopes[q]) {
+            total -= scopes[change];
+            scopes[change] = -1 * scopes[change];
+            total += scopes[change];
+        }
+        
+        cout << total << "\n";
+    }
+
+    
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터

### 알고리즘
- 구현

### 시간복잡도
- 초기 사전 계산 (mulnSum, sumAll)은 O(N)
- 각 쿼리는 최대 4개의 범위만 수정 → O(1)
- 총 시간복잡도는 **O(N + Q)**로, N, Q ≤ 200,000에서도 시간초과 없음 ✅

### 배운 점
- 시간복잡도 계산을 잘해야 하는 문제였다. Q번 input 들어오며 N번을 돌기만 해도 20만*20만 <- 2초여도 부족
- 조회 및 계산의 시간복잡도를 낮출 수 있도록 변수와 벡터(리스트)를 적극 활용했다.
    - 벡터
        - 범위별(시작지점 인덱스에 둠) - 곱한 값을 넣어둔다 `scopes[시작점] = 연속4칸의곱`
        - 번호별 - 각 어떤 범위에 있는지 넣어둔다 `whatScopes[소 지점] = {1,2,7,8} `
    - 변수: total
        - 총 값을 구한 뒤, 4번 (whatScopes에 들어있는 범위의 값)을 빼고, *(-1)을 해서 다시 더해주면 된다.