### PR TITLE
Solved: [그래프 탐색] BOJ_트리의 부모 찾기 홍지우

### DIFF
--- a/그래프 탐색/지우/BOJ_11725_트리의 부모 찾기.cpp
+++ b/그래프 탐색/지우/BOJ_11725_트리의 부모 찾기.cpp
@@ -1,0 +1,41 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+
+using namespace std;
+
+int main() {
+    int N; cin >> N;
+    vector<vector<int>> adj(N+1,vector<int>(0,0));
+
+    for(int i=0; i<N-1; i++) {
+        int a; int b;
+        cin >> a >> b;
+
+        adj[a].push_back(b);
+        adj[b].push_back(a);
+    }
+    
+    vector<int> p(N+1, 0);
+    p[1] = 1;
+
+    queue<int> q;
+    q.push(1);
+    while(!q.empty()) {
+        int par = q.front(); q.pop();
+
+        for(auto child : adj[par]) {
+            if(p[child] == 0) {
+                p[child] = par;
+                q.push(child);
+            }
+        }
+    }
+
+    for(int i=2; i<=N; i++) {
+        cout << p[i] << "\n";
+    }
+
+    
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터(리스트)
- 큐

### 알고리즘
- 그래프탐색(BFS)

### 시간복잡도
- 간선 입력은 N-1번으로 O(N)
- BFS 순회는 각 노드를 한 번씩 방문하므로 O(N)
- 전체 시간복잡도는 O(N)

### 배운 점
- **`트리의 루트 = bfs의 시작점`** 라는 아이디어 필요
    - 양방향 리스트로 저장해도, 시작점 먼저 타기 시작하면 결국 방문하는 건 단방향이 되면서 부모->자식 흐름이 가능해짐
- q에 먼저 들어간 것이 부모(par), 아직 방문하지 않고 부모(par)의 인접리스트에 있는 것이 자식(child) ◀️ `p[Child] = par` 로 반영해주기