### PR TITLE
Solved: [그래프 탐색] BOJ_쉬운 최단거리 홍지우

### DIFF
--- a/그래프 탐색/지우/BOJ_14940_쉬운 최단거리.cpp
+++ b/그래프 탐색/지우/BOJ_14940_쉬운 최단거리.cpp
@@ -1,0 +1,72 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+
+using namespace std;
+
+int n; int m;
+int tr; int tc;
+vector<vector<int>> maps;
+vector<vector<int>> dp;
+
+int dr[] = {1,0,-1,0};
+int dc[] = {0,1,0,-1};
+
+bool inRange(int r, int c) {
+    return r>=0 && r<n && c>=0 && c<m;
+}
+
+void bfs(int r, int c) {
+    
+    queue<vector<int>> q;
+    q.push({r,c});
+
+    while(!q.empty()) {
+        vector<int> curr = q.front(); q.pop();
+        int cr = curr[0];
+        int cc = curr[1];
+
+        for(int d=0; d<4; d++) {
+            int nr = cr + dr[d];
+            int nc = cc + dc[d];
+            if(inRange(nr, nc) && maps[nr][nc] != 0  && dp[nr][nc] == -1) {
+                dp[nr][nc] = dp[cr][cc]+1;
+                q.push({nr, nc});
+            }
+        }
+    }
+
+    return;
+    
+}
+
+int main() {
+    cin >> n >> m;
+    maps.resize(n, vector<int>(m, 0));
+    dp.resize(n, vector<int>(m,-1));
+
+    for(int r=0; r<n; r++) {
+        for(int c=0; c<m; c++) {
+            int a; cin >> a;
+            maps[r][c] = a;
+            if(a == 2) {
+                tr = r; tc = c;
+                dp[r][c] = 0;
+            } 
+            else if(a == 0) {
+                dp[r][c] = 0;
+            }
+        }
+    }
+
+    bfs(tr,tc);
+
+    for(int r=0; r<n; r++) {
+        for(int c=0; c<m; c++) {
+            cout << dp[r][c] << " ";
+        }
+        cout << "\n";
+    }
+
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터
- 큐

### 알고리즘
- 그래프탐색
- bfs

### 시간 복잡도
- **2차원 배열에서 bfs 한 번당 O(N*M)**
- bfs(tr, tc)는 단일 BFS로 모든 칸을 최대 한 번씩 방문 → O(n × m)
- main()에서 입력 처리 및 출력 포함한 나머지 연산도 O(n × m)

### 배운 점
- 처음에 2차원배열 bfs() 시간복잡도를 1000^2 일거라고 생각하지 못하고 품
     - 모든 정점을 방문하면서 타겟까지 bfs() 돌림 <- 1000^4 되면 당연히 시간초과
- 시초 보자마자 떠올림 -> dp[][] 즉, dist 배열에 저장하면서 나아가야겠다..
    - 우선 dp[][] 초기값을 -1로 둔다 (왜? 타겟에서 출발한 bfs가 못 도달하면 -1로 그대로 남아있어야 하기 때문)
    - 타겟일 때, 0 일 때는 무조건 dp[][] 가 0일 수 밖에 없다 <- 갱신이 필요하지 않으니 미리 `dp[][] = 0; `으로 세팅해준다.
    - 시작점을 타겟으로 하여 상,하,좌,우를 n*m 박스 안에서 계속 돌리며 `dp[][]==-1` <- 즉, visited되지 않은 곳을 찾아 타겟부터 해당 지점까지의 거리를 넣어준다.