### PR TITLE
Solved: [구현] BOJ_트리 순회 홍지우

### DIFF
--- a/구현/지우/BOJ_22856_트리 순회.cpp
+++ b/구현/지우/BOJ_22856_트리 순회.cpp
@@ -1,0 +1,46 @@
+#include <iostream>
+#include <vector>
+
+using namespace std;
+
+int N; int ans = -1;
+vector<vector<int>> childs;
+
+void dfs(int curr, bool containLast) {
+
+    if(curr == -1) return;
+    
+    int left = childs[curr][0];
+    int right = childs[curr][1];
+
+    ans++; // 현재 노드에 도달
+    
+    dfs(left, false); // 왼쪽 - 무조건 왕복
+    if(containLast) dfs(right, true); // 마지막 노드 포함 경로, 오른쪽은 편도만 이동
+    else {
+        ans++; // 왕복까지 포함
+        dfs(right, false); 
+    }
+
+
+    return;
+}
+
+
+int main() {    
+    cin >> N;
+    childs.assign(N+1, vector<int>(2,0));
+
+    for(int i=0; i<N; i++) {
+        int a; int b; int c;
+        cin >> a >> b >> c;
+
+        childs[a][0] = b; 
+        childs[a][1] = c;    
+    }
+
+    dfs(1,true); // 어차피 containLast 경로는 루트로부터 시작되니까 true로 넘기고, 들어가면 left, right(containLast경로=True)로 쪼갠다.
+    cout << ans;
+    
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터

### 알고리즘
- 구현
- 재귀

### 시간복잡도
트리의 노드 수는 최대 N = 100,000개로 주어진다.
각 노드는 DFS로 정확히 한 번씩 방문되며, 각각의 자식 노드(왼쪽/오른쪽)에 대해 최대 한 번씩만 재귀 호출이 이루어진다.
따라서 전체 DFS의 시간복잡도는 O(N) 이다.

### 배운 점
- 1차 시도) 그냥 dfs로 돌리고 마지막 노드 == N 일 때의 경로 깊이를 return 했다
    - '순회의 마지막 노드'가 꼭 N 이란 법이 없다. 
    - 중위순회를 따르기 때문
    -   /  1
    - 2 인 경우, `1-> 2 ->1` 이렇게 되어야 한다. (오른쪽이 있는지 확인해야 하기 때문)

- SOLVED: 왼쪽인 경우 왕복, 오른쪽인 경우 1) 마지막 경로를 포함하는 경로라면 일방향 2) 아니라면 왕복 의 아이디어를 가져옴
    - 왼쪽 가자! ans++(디폴트) + else 문의 ans++ <- 총 2회의 ++
    - 오른쪽 가자!! 
        - 마지막노드포함경로 : ans++(디폴트) 딱 한 번
        - 그거 안 포함: 이면 ans++(디폴트) + else 문의 ans++ <- 총 2회의 ++
        