### PR TITLE
Solved: [구현] BOJ_HTML 파싱 홍지우

### DIFF
--- a/구현/지우/BOJ_22859_HTML 파싱.cpp
+++ b/구현/지우/BOJ_22859_HTML 파싱.cpp
@@ -1,0 +1,90 @@
+#include <iostream>
+#include <deque>
+
+using namespace std;
+
+int main() {
+    string input;
+    getline(cin, input); // 한 줄 전부 다 받는 법
+
+    deque<string> dq;
+
+    int idx = 0;
+    while(idx < input.length()) {
+
+        string tmp = "";
+
+        if(input[idx] != '<') {
+            while(input[idx] != '<') {
+                tmp += input[idx++];
+            } 
+        }
+        else {
+            while(input[idx] != '>') {
+                tmp += input[idx++];
+            }
+            tmp += input[idx++];
+        }
+        dq.push_back(tmp);
+    }
+
+    while(!dq.empty()) {
+        
+        string s = dq.front();
+        // cout << s << "\n";
+
+        if(s[1] == '/') {
+            dq.pop_front();
+        }
+        else if(s[1] == 'm') {
+            dq.pop_front();
+        }
+        else if(s[1] == 'd') {
+            int idx = 11;
+            string tmp = "title : ";
+            while(idx < s.length()) {
+                if(s[idx] == '"') {
+                    idx++;
+                    while(s[idx] != '"') {
+                        tmp += s[idx++];
+                    }
+                    break;
+                }
+                idx++;
+            }
+            cout << tmp << "\n";
+            dq.pop_front();
+        }
+        else if(s[1] == 'p') {
+
+            string tmp = "";
+            dq.pop_front();
+            while(dq.front() != "</p>") {
+                string curr = dq.front();
+                if(curr[0] != '<') { // 괄호 없는 썡글자일 경우
+                    tmp += curr;
+                }
+                dq.pop_front();
+            }
+
+            // 공백이 2개 이상 연속 붙어있다면 하나의 공백으로 바꾼다.
+            // 문장과 시작과 끝에 공백이 있다면 지운다.
+            string result = "";
+            for(int i=0; i<tmp.length(); i++) {
+                if((i==0 || i==tmp.length()) && tmp[i] == ' ') {
+                    continue;
+                }
+                else if(i!=0 && tmp[i-1] == ' ' && tmp[i] == ' ') {
+                    continue;
+                }
+
+                result += tmp[i];
+            }
+            
+            cout << result << "\n";
+            dq.pop_front();
+        }
+    }
+    
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 덱
- string

### 알고리즘
- 구현

### 시간복잡도
- HTML 문서 전체 길이가 최대 1,000,000이므로 input.length()는 최대 1백만입니다.
- 첫 번째 while문에서는 각 문자마다 한 번씩만 탐색하고, <...> 또는 일반 텍스트 단위를 deque에 저장하므로 O(N).
- 두 번째 while문에서도 deque에서 각 요소를 한 번씩만 처리하므로 전체 시간복잡도는 **O(N)**입니다.

### 배운 점
- 공백을 포함한 한 줄을 그대로 받는 법: `getline(cin, 변수명)`
- 한 번에 돌아가서.. 넘 후 감 격 스 러 워 요.. (그치만.. 코드가 좀 더러워용.. 헤헤ㅔ)
- 1번째 while문: 덱에 `[ <main> | <div title=" "> | <p> | paragraph 2 | <i> | Italic Tag | </i> | <br > | </p> ,,,] `이런식으로 넣는다
- 2번째 While문: 
     -  / 닫힌 건 무시한다. (main, div의 닫힘 태그) + main도 무시
     - div 여는 태그: " " 안에 있는 글자만 뽑아서 출력한다.
     - p 태그 안: 다른 태그(i br),쌩글자 둘 중 하나가 있다. 이때, 쌩글자만 tmp에 모아서 출력할 준비
          - 2가지 조건(시작 끝 공백 ❌  + 2 공백 연속 ❌ ) 만족하게끔 For문 검사