### PR TITLE
Solved: [그래프 탐색] BOJ_단지번호붙이기 홍지우

### DIFF
--- a/그래프 탐색/지우/BOJ_2667_단지번호붙이기.cpp
+++ b/그래프 탐색/지우/BOJ_2667_단지번호붙이기.cpp
@@ -1,0 +1,73 @@
+#include <iostream>
+#include <queue>
+#include <algorithm>
+#include <vector>
+
+using namespace std;
+
+int N; int currNum;
+vector<vector<int>> maps; vector<int> counts;
+queue<pair<int,int>> q;
+
+int dr[] = {-1, 0, 1, 0};
+int dc[] = {0, 1, 0, -1};
+
+bool inRange(int r, int c) {
+    return r>=0 && r<N && c>=0 && c<N;
+}
+
+void bfs(int r, int c) {
+    maps[r][c] = currNum; 
+    int cnt = 0;
+    
+    q.push({r,c});
+    while(!q.empty()) {
+        pair curr = q.front(); q.pop();
+        cnt++;
+
+        for(int d=0; d<4; d++) {
+            int nr = curr.first + dr[d];
+            int nc = curr.second + dc[d];
+
+            if(inRange(nr, nc) && maps[nr][nc] == 1) {
+                maps[nr][nc] = currNum;
+                q.push({nr, nc});
+            }
+        }
+    }
+
+    counts.push_back(cnt);
+}
+
+int main() {
+    
+    cin >> N;
+    currNum = 2;
+    maps.resize(N, vector<int>(N, 0));
+    counts.resize(0);
+
+    for(int r=0; r<N; r++) {
+        string s; cin >> s;
+        for(int c=0; c<N; c++) {
+            int input; input = s[c] - '0';
+            maps[r][c] = input;
+        }
+    }
+
+    for(int r=0; r<N; r++) {
+        for(int c=0; c<N; c++) {
+            if(maps[r][c] == 1) {
+                bfs(r, c);
+                currNum++;
+            }
+        }
+    }
+
+    sort(counts.begin(), counts.end());
+
+    cout << counts.size() << "\n";
+    for(int i=0; i<counts.size(); i++) {
+        cout << counts[i] << "\n";
+    } 
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터
- 큐

### 알고리즘
- 그래프탐색 - BFS

### 시간복잡도
- 입력 및 2중 for문 전체 탐색 → O(N²)
- BFS에서 각 칸은 한 번만 방문 → 전체 BFS 시간도 O(N²)
- 정렬(sort)은 O(K log K) (K는 단지 수, 최대 N² 이하)

### 배운 점
- counts[currNum]에 cnt 담으려고 했더니 이러면 공간 다 만들어줘야 하잖아.? <- 그냥 인덱스는 안 중요하니까 counts.push_back(cnt)만 해도 되네~
- vis 안 씀. 지나간 곳은 2이상의 currNum으로 채워줌. (같은 집단끼리는 같은 숫자가 채워지게끔) 
    - 주변에 1이 있으면 가서 currNum으로 바꿔주기
    - 전체 체크할 때도 1인 곳만 가서 섬 탐색 시작하기