### PR TITLE
Solved: [그래프 탐색] BOJ_미로 탐색 홍지우

### DIFF
--- a/그래프 탐색/지우/BOJ_2178_미로 탐색.cpp
+++ b/그래프 탐색/지우/BOJ_2178_미로 탐색.cpp
@@ -1,0 +1,52 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+
+using namespace std;
+
+int N; int M; 
+int dr[] = {-1, 0, 1, 0};
+int dc[] = {0, -1, 0, 1};
+
+bool inRange(int r, int c) {
+    return r>=0 && r<N && c>=0 && c<M;
+}
+
+int main() {
+    cin >> N >> M;
+
+    vector<vector<int>> maps(N, vector<int>(M));
+    vector<vector<int>> dp(N, vector<int>(M));
+    for(int r=0; r<N; r++) {
+        string s; cin >> s;
+        for(int c=0; c<M; c++) {
+            int in; in = s[c]-'0';
+            maps[r][c] = in;
+        }
+    }
+
+    queue<pair<int, int>> q;
+    q.push({0,0});
+    dp[0][0] = 1;
+
+    while(!q.empty()) {
+        pair<int, int> curr = q.front(); q.pop();
+
+        if(curr.first == N-1 && curr.second == M-1) break;
+
+        for(int d=0; d<4; d++) {
+            int nr = curr.first + dr[d];
+            int nc = curr.second + dc[d];
+
+            if(inRange(nr, nc) && maps[nr][nc] == 1) {
+                maps[nr][nc] = 0;
+                dp[nr][nc] = dp[curr.first][curr.second]+1;
+                q.push({nr, nc});
+            }
+        }
+    }
+
+    cout << dp[N-1][M-1];
+    
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터
- 큐

### 알고리즘
- 그래프 탐색(BFS)

### 시간복잡도
1. 입력 처리 및 2차원 배열 초기화 → **O(N × M)**
2. BFS에서 각 칸은 **최대 한 번만 방문** → **O(N × M)**
3. 큐 연산 및 인접 4방향 확인도 모두 합쳐 **O(4 × N × M) = O(N × M)**

🔹 **총 시간복잡도: O(N × M)**

### 배운 점
- '최단거리' -> `거리 저장 배열` 활용 혹은 `node에 현재까지의 거리 포함시켜서 다니기`
- 아까 문제와 다른 점은 인접한 node 묶음의 '개수'를 세지 않는 것이다.
    - 인접한 걸 세려면 그냥 cnt만 하면 됨 ABCDEF 6
    - 그러나 이 친구는 '최단거리'를 묻고 있음. A > C > E 거리:3 
<img width="318" height="159" alt="image" src="https://github.com/user-attachments/assets/5bb02efe-7eaf-43ec-a742-467e9120a3e1" />
