### PR TITLE
Solved: [그래프 탐색] BOJ_숨바꼭질 3 홍지우

### DIFF
--- a/그래프 탐색/지우/BOJ_13549_숨바꼭질 3(ver.PQ).cpp
+++ b/그래프 탐색/지우/BOJ_13549_숨바꼭질 3(ver.PQ).cpp
@@ -1,0 +1,44 @@
+#include <iostream>
+#include <queue>
+#include <set>
+
+using namespace std;
+
+int N, K;
+
+int main() {
+    cin >> N >> K;
+    
+    priority_queue< pair<int,int>, vector<pair<int,int>>, greater<pair<int,int>> > pq;
+    // priority_queue<pair<int, int>> pq;  --  큰 수부터 출력됨
+    
+    set<int> viss;
+    pq.push({0, N});
+
+    while(!pq.empty()) {
+        pair<int,int> curr = pq.top(); pq.pop();
+        int t = curr.first;
+        int x = curr.second;
+
+        if(x==K) {
+            cout << t;
+            return 0;
+        }
+
+        if(2*x <= 100000 && !viss.count(2*x)) {
+            viss.insert(2*x);
+            pq.push({t, 2*x});
+        }
+        if(x-1>=0 && !viss.count(x-1)) {
+            viss.insert(x-1);
+            pq.push({t+1, x-1});
+        }
+        if(x+1 <= 100000 && !viss.count(x+1)) {
+            viss.insert(x+1);
+            pq.push({t+1, x+1});
+        }
+        
+    }
+     
+    return 0;
+}

--- a/그래프 탐색/지우/BOJ_13549_숨바꼭질 3(ver.Q).cpp
+++ b/그래프 탐색/지우/BOJ_13549_숨바꼭질 3(ver.Q).cpp
@@ -1,0 +1,41 @@
+#include <iostream>
+#include <queue>
+#include <set>
+
+using namespace std;
+
+int N, K;
+
+int main() {
+    cin >> N >> K;
+    queue<pair<int,int>> q;
+    set<int> viss;
+    q.push({N, 0});
+
+    while(!q.empty()) {
+        pair<int,int> curr = q.front(); q.pop();
+        int x = curr.first;
+        int t = curr.second;
+
+        if(x==K) {
+            cout << t;
+            return 0;
+        }
+        
+        if(2*x <= 100000 && !viss.count(2*x)) {
+            viss.insert(2*x);
+            q.push({2*x, t});
+        }
+        if(x-1>=0 && !viss.count(x-1)) {
+            viss.insert(x-1);
+            q.push({x-1, t+1});
+        }
+        if(x+1 <= 100000 && !viss.count(x+1)) {
+            viss.insert(x+1);
+            q.push({x+1, t+1});
+        }
+        
+    }
+     
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- Queue
- Priority Queue
- set <- visited 처리용

### 알고리즘
- 그래프탐색(BFS)

### 시간복잡도
<html><head></head><body><p>두 코드 모두 <strong>숨바꼭질 (0-1 BFS / 다익스트라 변형)</strong> 문제를 풀고 있으며,<br>
시간복잡도 관점에서 다음과 같이 요약할 수 있습니다:</p>
<hr>
<h3>✅ <strong>1. BFS (Queue 사용)</strong></h3>
<pre><code class="language-cpp">queue&lt;pair&lt;int,int&gt;&gt; q;
</code></pre>
<h4>시간복잡도 요약:</h4>
<ol>
<li>
<p>각 위치는 최대 한 번만 방문됨 → O(1) 방문 처리</p>
</li>
<li>
<p>위치 수는 최대 100001개 → O(100001)</p>
</li>
<li>
<p>각 위치에서 최대 3개의 이동 시도 → 총 O(3 * 100001)</p>
</li>
</ol>
<p>✅ <strong>총 시간복잡도: O(100000)</strong> → <strong>선형 시간</strong></p>
<hr>
<h3>✅ <strong>2. 다익스트라 (Priority Queue 사용)</strong></h3>
<pre><code class="language-cpp">priority_queue&lt;pair&lt;int,int&gt;, vector&lt;pair&lt;int,int&gt;&gt;, greater&lt;pair&lt;int,int&gt;&gt;&gt; pq;
</code></pre>
<h4>시간복잡도 요약:</h4>
<ol>
<li>
<p>우선순위 큐 사용으로 삽입/삭제가 O(log N)</p>
</li>
<li>
<p>최대 100001개의 노드가 들어갈 수 있음</p>
</li>
<li>
<p>각 노드에서 최대 3개의 인접 노드 탐색</p>
</li>
</ol>
<p>✅ <strong>총 시간복잡도: O(3 * N log N) = O(N log N)</strong><br>
➡️ 여기서 N은 최대 100000이므로 약 <strong>O(100000 log 100000)</strong></p>
<hr>
<h3>🔍 요약 비교</h3>

방식 | 시간복잡도 | 설명
-- | -- | --
BFS (Queue) | O(N) | 0-1 가중치 특성 활용 (최적)
다익스트라 (PQ) | O(N log N) | 일반적인 가중치 처리용 (조금 느림)


### 배운 점
- 가장 빨리 도달할 수 밖에 없는 로직을 Q에 가장 먼저 넣어야 하는 아이디어가 필요했다.
- 따라서 Q도 time 추가가 없는 2x를 먼저 돌리면 맞는 문제였다.
- PQ는 그거와 관계없이 가장 빠른 수가 나올 수 있게 도왔다. 근데 일단 2*x가 먼저 처리 되어야 viss 처리를 선점하니 위치 차이도 상관이 있긴 하다.

- PQ 사용법
    - priority_queue<pair<int, int>> pq;
    - priority_queue< pair<int,int>, vector<pair<int,int>>, greater<pair<int,int>> > pq; // 값 작은 순으로 출력