### PR TITLE
Solved: [그래프 탐색] BOJ_ABCDE 김나영

### DIFF
--- a/그래프 탐색/나영/BOJ_13023_ABCDE.java
+++ b/그래프 탐색/나영/BOJ_13023_ABCDE.java
@@ -1,0 +1,55 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int n, m, ans;
+    static List<Integer> list[];
+    static boolean visited[];
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        list = new ArrayList[n];
+        visited = new boolean [n];
+        
+        for (int i = 0; i < n; i++) {
+            list[i] = new ArrayList<>();
+        }
+
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            list[a].add(b);
+            list[b].add(a);
+        }
+
+        for (int i = 0; i < n; i++) {
+            if (ans != 1) dfs(i, 1);
+        }
+        
+        System.out.println(ans);
+    }
+
+    static void dfs(int c, int cnt) {
+        if (cnt == 5) {
+            ans = 1;
+            return;
+        }
+        
+        visited[c] = true;
+
+        for (int i : list[c]) {
+            if (!visited[i]) {
+                dfs(i, cnt + 1);
+            }
+        }
+        
+        visited[c] = false;
+    }
+}


### PR DESCRIPTION
### 자료구조
- 배열
- ArrayLisst

### 알고리즘
- 그래프 탐색
- DFS

### 시간복잡도
- ArrayList 생성 : O(n)
- 입력 및 list에 자식 삽입 : O(m)
- DFS : 최악의 경우 O(n ^ 5)
    - 모든 노드가 서로 연결되어 있는 경우 P(n,5) = O(n ^ 5)까지 돌 수 있지만, 
        - dfs() 에서 visited로 중복 경로 탐색을 방지하고
        - ans가 1이면 dfs가 중단되므로
    - 최악의 경우까지 가지 않는다.

### 배운점

<img width="571" height="309" alt="image" src="https://github.com/user-attachments/assets/933a5c88-9d22-441b-a701-d3d339b4cbbe" />

- 종이랑 펜 꺼내기 귀찮아서 이 꼴로 풂
- 생각보다 심플한 DFS 문제였슴
- visited로 경로 탐색 도중에 이미 지나간 노드에 대해 재접근을 막음
- 그리고 외부 for문에서 문제가 원하는 케이스를 찾을 경우 그 이후의 노드에 대한 DFS 탐색을 하지 않도록 했습니다.