### PR TITLE
Solved: [그래프 탐색] BOJ_토마토1 홍지우

### DIFF
--- a/그래프 탐색/지우/BOJ_7576_토마토/토마토(ver.bfs).cpp
+++ b/그래프 탐색/지우/BOJ_7576_토마토/토마토(ver.bfs).cpp
@@ -1,0 +1,70 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+
+using namespace std;
+
+int C, R; int ans;
+int unripeCnt;
+queue<vector<int>> q;
+vector<vector<int>> maps;
+
+int dr[] = {-1,0,1,0};
+int dc[] = {0,1,0,-1};
+
+bool inRange(int r, int c) {
+    return r>=0 && r<R && c>=0 && c<C;
+}
+
+int bfs() {
+    while(!q.empty()) {
+        vector<int> curr = q.front(); q.pop();
+        int r = curr[0]; int c = curr[1]; 
+        ans = max(ans, maps[r][c]);
+        
+        for(int d=0; d<4; d++) {
+            int nr = r + dr[d];
+            int nc = c + dc[d];
+
+            if(inRange(nr, nc) && maps[nr][nc] == 0) {
+                maps[nr][nc] = maps[r][c] + 1;
+                unripeCnt--;
+                q.push({nr,nc});
+            }
+        }
+    }
+
+    if(unripeCnt == 0) {
+        return ans-1;
+    } else {
+        return -1;
+    }
+    
+}
+
+int main() {
+    cin.tie(0); ios::sync_with_stdio(0);
+    cin >> C >> R; 
+    maps.resize(R, vector<int>(C,0));
+    
+    for(int r=0; r<R; r++) {
+        for(int c=0; c<C; c++) {
+
+            int in; cin >> in; maps[r][c] = in;
+            if(in == 1) {
+                q.push({r,c});
+            } else if(in == 0) {
+                unripeCnt++;
+            }
+        }
+    }
+
+    if(unripeCnt == 0) {
+        cout << 0;
+        return 0;
+    }
+
+    cout << bfs();
+    
+    return 0;
+}

--- a/그래프 탐색/지우/BOJ_7576_토마토/토마토(ver.dfs_시초).cpp
+++ b/그래프 탐색/지우/BOJ_7576_토마토/토마토(ver.dfs_시초).cpp
@@ -1,0 +1,86 @@
+// dfs(시초)
+#include <iostream>
+#include <vector>
+
+using namespace std;
+
+int N, M;
+int ripeCnt, unripeCnt;
+vector<vector<int>> maps;
+vector<vector<bool>> vis;
+int ans; int prvCnt;
+
+int dr[] = {-1,0,1,0};
+int dc[] = {0,1,0,-1};
+
+bool inRange(int r, int c) {
+    return r>=0 && r<N && c>=0 && c<M;
+}
+
+void dfs(int cnt, int timeCnt) {
+    int minusCnt =0;
+    vis.assign(N, vector<bool>(M, false));
+
+    if(cnt == 0) {
+        ans = timeCnt;
+        return;
+    }
+
+    if(prvCnt == cnt) {
+        ans = -1;
+        return;
+    }
+
+    for(int r=0; r<N; r++) {
+        for(int c=0; c<M; c++) {
+            if(!vis[r][c] && maps[r][c] == 1) {
+                vis[r][c] = true;
+                for(int d=0; d<4; d++) {
+                    int nr = r + dr[d];
+                    int nc = c + dc[d];
+
+                    if(inRange(nr, nc) && !vis[nr][nc] && maps[nr][nc] == 0) {
+                        vis[nr][nc] = true;
+                        maps[nr][nc] = 1;
+                        minusCnt++;
+                    }
+                }
+            }
+        }
+    }
+
+    prvCnt = cnt;
+    dfs(cnt - minusCnt , timeCnt+1);
+    return;
+}
+
+int main() {
+    cin.tie(0);
+    ios::sync_with_stdio(0);
+    
+    cin >> M >> N;
+    maps.resize(N, vector<int>(M));
+
+    for(int r=0; r<N; r++) {
+        for(int c=0; c<M; c++) {
+            int input; cin >> input;
+            maps[r][c] = input;
+            if(input == 0) {
+                unripeCnt++;
+            }
+            else if(input == 1) {
+                ripeCnt++;
+            }
+        }
+    }
+
+    if(unripeCnt == 0) {
+        cout << 0;
+        return 0;
+    }
+
+    dfs(unripeCnt, 0);
+    cout << ans;
+    
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터
- 큐

### 알고리즘
- 그래프탐색(BFS)
- DFS _ 시간초과

---
### 시간복잡도
이렇게 동시에 여러 군데로 퍼져나가는 문제는 BFS를 '먼저' 떠오르는 버릇을 들이자.
#### `BFS`
1. 큐에 들어간 각 칸은 최대 1번만 방문됨 → O(N*M)
2. 각 칸마다 상하좌우 4방향 확인 → 4 * O(N*M)
3. 전체 시간복잡도는 **O(N*M)** 으로 매우 효율적

#### `DFS`
1. 매 단계마다 전체 맵을 2중 for문으로 탐색 → O(N*M)
2. 각 재귀마다 새로 방문배열 초기화 + 깊이탐색 → 최대 N*M번 재귀
3. 전체 시간복잡도는 **O((N*M)^2)** 이상 → **TLE 발생**
---

### 배운 점
- BFS, DFS 어떤 문제에 쓸지 잘 생각하고 들어가자. 쩨발!!

- 큐에 넣을 친구가 들어온다 -> 큐에 바로 넣는다 : 이렇겐 처음 풀어봤다..
    - 큐에 남은 애들 = 익은 토마토 
    - 큐가 empty 될 때까지 -> 익은 토마토가 미치는 영향이 없어질 때까지


- vis 안 쓰고 걸린 시간 dp 맵도 안 쓰고 풀어봤음
    - 그대신 maps에 익은 애들을 [이전+1]로 쌓아가며 시간 관련 숫자들로 채웠음 (그럼 '0'인 곳만 찾아서 가니 어차피 vis 역할을 함)
    - 익은 애들의 영향 -> 다음 map `안 익 -> 익` 할 때, `이전 익은` 애+1 하면? 거기까지 가는데 걸린 시간+1
        - 초기 익은 애: map[][] = 1
            - 얘 때문에 다음에 익힌 애: map[][] = 이전+1 = 2 (즉, 여기까지 걸린 시간이 저장된다. 근데 시작이 1이라서 나중에 1 빼줘야 함)