### PR TITLE
Solved: [그래프 탐색] BOJ_숫자고르기 홍지우

### DIFF
--- a/그래프 탐색/지우/BOJ_2668_숫자고르기/숫자고르기(ver.dfs).cpp
+++ b/그래프 탐색/지우/BOJ_2668_숫자고르기/숫자고르기(ver.dfs).cpp
@@ -1,0 +1,44 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+
+int N; int start;
+vector<int> arr; vector<int> ans;
+vector<bool> vis;
+
+bool dfs(int curr) {
+    int nxt = arr[curr];
+    if(!vis[nxt]) {
+        vis[nxt] = true;
+        if(dfs(nxt)) return true;
+    }
+    else if(nxt == start) {
+        ans.push_back(start);
+        return true;
+    }
+
+    return false;
+}
+
+int main() {
+    cin >> N;
+    arr.resize(N+1,0);
+    for(int i=1; i<=N; i++) {
+        cin >> arr[i];
+    }
+
+    for(int s=1; s<=N; s++) {
+        vis.assign(N+1, false); vis[s] = true;
+        start = s;
+        dfs(s);
+    }
+
+    sort(ans.begin(), ans.end());
+    cout << ans.size() << "\n";
+    for(auto node : ans) {
+        cout << node << "\n";
+    }
+    return 0;
+}

--- a/그래프 탐색/지우/BOJ_2668_숫자고르기/숫자고르기(ver.조합-시초).cpp
+++ b/그래프 탐색/지우/BOJ_2668_숫자고르기/숫자고르기(ver.조합-시초).cpp
@@ -1,0 +1,75 @@
+//조합(시초)
+#include <iostream>
+#include <vector>
+#include <set>
+#include <algorithm>
+
+using namespace std;
+
+int N; 
+vector<int> arr;
+vector<bool> vis;
+vector<pair<int,int>> ans;
+set<int> set1; set<int> set2;
+
+bool check(vector<pair<int,int>> pics) {
+    set1.clear(); set2.clear();
+    
+    for(int i=0; i<pics.size(); i++) {
+        set1.insert(pics[i].first);
+        set2.insert(pics[i].second);
+    }
+
+    return set1 == set2;
+}
+
+bool dfs(int groupSize, vector<pair<int,int>>& pics, int start) {
+    if(groupSize == pics.size()) {
+        if(check(pics)) {
+            ans = pics;
+            return true;
+        }
+        return false;
+    }
+
+    if(pics.size() + (N - start +1) < groupSize) { // 남은거 다 더해도 group 안돼? - 자르기 
+        return false;
+    }
+
+    for(int i=start; i<=N; i++) {
+        pics.push_back({i, arr[i]});
+        if(dfs(groupSize, pics, i+1)) return true;
+        pics.pop_back();
+    }
+
+    return false;
+}
+
+int main() {
+    cin.tie(0); cout.tie(0);
+    ios::sync_with_stdio(0);
+    
+    cin >> N;
+    arr.resize(N+1);
+    vis.assign(N+1, false);
+
+    for(int i=1; i<=N; i++) {
+         cin >> arr[i];
+    }
+
+    for(int i=N; i>=1; i--) { // 집합 개수
+        vector<pair<int,int>> pics;
+        if(dfs(i, pics, 1)) {
+            break;
+        }
+    }
+
+    sort(ans.begin(), ans.end());
+    cout << ans.size() << "\n";
+    for(int i=0; i<ans.size(); i++) {
+        cout << ans[i].first << "\n";
+    }
+    
+    
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터
- set(dfs의 경우)

### 알고리즘
- 그래프탐색(DFS)
- 조합으로 풀었더니 시초 엔딩 코히히

---
### 시간복잡도

#### DFS
1. 각 노드에서 한 번씩 DFS 수행 → O(N)
2. DFS 안에서 순환 탐색은 최대 O(N)
3. 전체 시간복잡도는 **O(N^2)** → N ≤ 100 이면 충분히 통과 가능

#### 조합(백트래킹)
1. 크기가 1~N인 조합을 모두 생성 → O(2^N)
2. 각 조합마다 `check()` 함수에서 집합 비교 → O(N log N)
3. 전체 시간복잡도는 **O(2^N × N)** → N = 100일 때는 **절대 불가능**

#### 조합 시간초과 이유
1. 가능한 모든 조합을 만들고 확인하려고 하므로 경우의 수가 **지수적으로 증가 (2^N)**  
2. 그 중에서도 정답이 후반부에 있어야만 멈추므로 대부분의 경우 **모든 조합을 탐색**
3. DFS 방식은 "사이클 여부만 확인"하므로 선형으로 동작, 조합은 불필요하게 낭비적인 탐색 

---

### 배운 점
#### DFS
- 솔직히.. 진짜.. 어려웠다.. 조합으로 풀고 그 방식대로 dfs로 넘어가는게 불가능했다.
     - 루프 도는 경로로 따라서 리스트로 저장하고 마지막에 ans에 다 넣어주면 굳이 한 번 더 안 돌겠지 생각했었다.
         - 이때 vis 관리하는게 복잡해지면서 로직이 꼬였다.
         - dfs 호출의 경로, 이전의 다른 dfs 호출에서 이미 탐색이 끝난 친구 vis를 따로 관리해야 했는데 정답을 발견했을 때의 처리가 어려웠다.(`for (int i = next; i != curr; i = arr[i])` { <- 이게 대체 뭐람..) 그래서 그냥 풀이법 바꿨다.


- 푼 방법: 그냥 간단하게 생각하는게 더 옳은 길
    - 루프는 어디서 시작하든 루프 안에 있게 된다.
        - node 수 최대 100이다 돈 루프 한 번 더 돈다고 세상이 돌진 않는다.
    - dfs를 타다가 다음 차례의 노드가`이미 방문한 곳 && 내 dfs 시작점`을 마주하면 그 시작점은 루프 속에 있는게 '확실'하다. => ans에 넣어준다.


#### 조합
- 집합 개수(groupsize)에 포커스를 뒀다. 
- N~1까지 집합 개수를 설정하고 그만큼의 그룹을 만들 수 있도록 조합을 돌렸다. 
    - 해당 집합 개수 안에서 사이클이 생기면 그때의 groupsize가 답이 될 수 있도록
- 근데 .. 이거 쓰면서 생각했는데 굳이 N번 돌면서 집합 개수 안 정해줘도 되겠다. 
    - 그냥 모든 부분 집합의 경우의 수 재귀 태우고 index가 N까지 다 돌면 그때의 모아진 리스트 검사해도 되겠다. 리스트의 size로 groupSize max로 구하고 앗챠챠..
    - 근데 이래도 2^N 걸려서 시초 엔딩 헤헤 ### 살려줘요 DFS@@