### PR TITLE
Solved: [그래프 탐색] BOJ_샘터 홍지우

### DIFF
--- a/그래프 탐색/지우/BOJ_18513_샘터.cpp
+++ b/그래프 탐색/지우/BOJ_18513_샘터.cpp
@@ -1,0 +1,51 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+#include <set>
+
+using namespace std;
+
+int N, K;
+vector<int> springs;
+set<int> vis; 
+priority_queue<vector<long long>, vector<vector<long long>>, greater<vector<long long>>> pq;
+long long ans; int homeCnt;
+
+int pluses[] = {-1, 1};
+
+void bfs() {
+    while(!pq.empty() && homeCnt < K) {
+        vector<long long> curr = pq.top(); pq.pop();
+        
+        long long distance = curr[0];
+        int x = curr[1];
+        int springPos = curr[2];
+        
+        homeCnt++;
+        ans += distance;
+
+        for(int i=0; i<2; i++) {
+            int nx = x + pluses[i];
+            if(!vis.count(nx)) {
+                long long nxtDistance = abs((long long)springPos - nx);
+                vis.insert(nx);
+                pq.push({nxtDistance, nx, springPos});
+            }
+        }
+    }
+}
+
+int main() {
+    cin.tie(0); ios::sync_with_stdio(0);
+    cin >> N >> K;
+    
+    for(int i=0; i<N; i++) {
+        int spring; cin >> spring; homeCnt--;
+        pq.push({0, spring, spring}); vis.insert(spring);
+    }
+
+    bfs();
+    cout << ans;
+    
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- Queue, Set, Vector

### 알고리즘
- 그래프탐색(BFS)

### 시간복잡도
BFS는 최대 K개의 집을 지을 때까지 확장되므로 반복 횟수는 O(K)
→ 큐에 들어가는 집의 수는 최대 K개까지, 매 루프마다 한 개씩 짓는다.

우선순위 큐에서 pop()/push()는 O(log K)
→ 큐 크기는 최대 K개이며, 힙 연산마다 log K 시간 소요.

전체 시간복잡도는 O(K log K)
→ K은 최대 100,000이므로 K log K ≈ 170만 → 충분히 통과 가능.

### 배운 점
- 사실 PQ 말고 그냥 Q 써도 됐다. 어차피 거리는 샘터 기준으로 +1씩 되니까. 그리고 더 빨리 도착한 애가 거리가 더 크면 어떡하지?! 이러면서 도입한 건데 - 어차피 먼저 큐에 들어가있어서 나오는 것도 더 빨리 나올 것이다. (훔훔.._ 힝구)

- 반례
    - (-100,000,000 ≤ 샘터의 위치 ≤ 100,000,000)  <- 이런 범위에 거리 나온다? 무조건! long long 타입 생각했어야. 참말로.
    - 문제에서 집의 범위를 따로 명시해두지 않았다. 다음 집 넣을 때 InRange로 샘터랑 동일 범위로 두니까 80%에서 틀렸다. *문제 잘 읽자 ^^

- 풀이법
    - 큐( 거리, 현재 POS, 시작된 샘터 POS )
    - PQ가 거리 기준으로 작은 것부터 자동정렬
    - 계속 꺼내면서 거리를 ans에 넣어주기. 
    - homeCnt가 K가 되면 그때까지 모인 ans 출력하기