### PR TITLE
Solved: [그래프 탐색] BOJ_빙산 김나영

### DIFF
--- a/그래프 탐색/나영/BOJ_2573_빙산.java
+++ b/그래프 탐색/나영/BOJ_2573_빙산.java
@@ -1,0 +1,105 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int n, m, size, ans;
+    static int map[][];
+    static boolean isS;
+    static boolean visited[][], wasIce[][];
+    static Queue<int []> que = new LinkedList<>();
+    static int dr[] = {-1, 0, 1, 0};
+    static int dc[] = {0, -1, 0, 1};
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        map = new int [n][m];
+        // visited = new boolean [n][m];
+        wasIce = new boolean [n][m];
+        
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < m; j++) {
+                int a = Integer.parseInt(st.nextToken());
+                if (a != 0) que.offer(new int [] {i, j});
+                map[i][j] = a;
+            }
+        }
+        
+        size = que.size();
+        if (!find()) isS = bfs();
+        
+        System.out.println(isS ? ans : 0);
+    }
+
+    static boolean bfs() {
+        while (!que.isEmpty()) {
+            if (size == 0) {
+                ans++;
+                
+                if (find()) return true;
+                
+                size = que.size();
+                wasIce = new boolean [n][m];
+            }
+            
+            int q[] = que.poll();
+            size--;
+            int r = q[0];
+            int c = q[1];
+
+            for (int d = 0; d < 4; d++) {
+                int nr = q[0] + dr[d];
+                int nc = q[1] + dc[d];
+
+                if (check(nr, nc) && map[nr][nc] == 0 && !wasIce[nr][nc]) {
+                    map[r][c]--;
+                    if (map[r][c] == 0) {
+                        wasIce[r][c] = true;
+                        break;
+                    }
+                }
+            }
+
+            if (map[r][c] != 0) que.offer(new int [] {r, c});
+        }
+
+        return false;
+    }
+
+    static boolean find() {
+        int cnt = 0;
+        visited = new boolean [n][m];
+        for (int ex[] : que) {
+            if (!visited[ex[0]][ex[1]]) {
+                dfs(ex[0], ex[1]);
+                cnt++;
+                if (cnt >= 2) return true;
+            }
+        }
+        return false;
+    }
+
+    static void dfs(int r, int c) {
+        if (visited[r][c]) return;
+
+        visited[r][c] = true;
+
+        for (int d = 0; d < 4; d++) {
+            int nr = r + dr[d];
+            int nc = c + dc[d];
+
+            if (check(nr, nc) && map[nr][nc] != 0) {
+                dfs(nr, nc);
+            }
+        }
+    }
+
+    static boolean check(int r, int c) {
+        return r >= 0 && r < n && c >= 0 && c < m;
+    }
+}


### PR DESCRIPTION
### 자료구조
- Queue
- 배열

### 알고리즘
- 그래프 탐색
- BFS
- DFS

### 시간복잡도
- 빙산의 최대 높이만큼 녹음 => O(H)
- 빙산의 갯수만큼 BFS, DFS 탐색 => O(I)
- 로직 시간복잡도 : O(H * I)
    - 빙산의 최대 높이는 10, 빙산의 최대 갯수는 10,000개

### 배운점
- 빙산이 녹으면 map에 0으로 반영하는데, 다음 빙산으로 넘어갈 때 바다인 부분이 해당 년도에 녹은 빙산의 위치인지를 확인해야 헀다
- 그래서 wasIce 배열을 통해 해당 년도에 빙산이 녹을 경우 그 위치에 true 처리해 빙산이었는지 아닌지 확인
- 그리고 find 메서드에서 dfs()를 남은 빙산 개수만큼 돌려 빙산이 2개 이상 분해되었는지 확인


<img width="300" height="168" alt="image" src="https://github.com/user-attachments/assets/e4aef2f5-914f-45af-b579-28bc0ac75fbb" />
