### PR TITLE
Solved: [그래프 탐색] BOJ_직사각형 탈출 홍지우

### DIFF
--- a/그래프 탐색/지우/BOJ_16973_직사각형 탈출.cpp
+++ b/그래프 탐색/지우/BOJ_16973_직사각형 탈출.cpp
@@ -1,0 +1,79 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+
+using namespace std;
+
+int N, M, H, W, sr, sc, fr, fc;
+int ans;
+vector<vector<int>> maps;
+vector<vector<int>> prefix;
+vector<vector<int>> dp;
+queue<pair<int,int>> q;
+
+int dr[] = {-1,0,1,0};
+int dc[] = {0,1,0,-1};
+
+bool inRange(int r, int c) {
+    int endR = r+H-1; int endC = c+W-1;
+    return r>=1 && r<=N && endR >=1 && endR <=N && c>=1 && c<=M && endC >=1 && endC<=M;
+}
+
+bool possible(int r, int c) {
+    int endR = r+H-1; int endC = c+W-1;
+    int sum = prefix[endR][endC] - prefix[r-1][endC] - prefix[endR][c-1] + prefix[r-1][c-1];
+    if(sum == 0) return true;
+    return false;
+}
+
+void bfs() {
+    while(!q.empty()) {
+        pair<int, int> curr = q.front(); q.pop();
+        int r = curr.first;
+        int c = curr.second;
+
+        if(r==fr && c==fc) {
+            ans = dp[r][c];
+            return;
+        }
+
+        for(int d=0; d<4; d++) {
+            int nr = r + dr[d];
+            int nc = c + dc[d];
+
+            if(inRange(nr, nc) && dp[nr][nc] == 0 && possible(nr, nc)) {
+                dp[nr][nc] = dp[r][c] + 1;
+                q.push({nr,nc});
+            }
+        }
+    }
+
+    return;
+}
+
+int main() {
+    cin.tie(0); cout.tie(0); ios::sync_with_stdio(0);
+    cin >> N >> M;
+    maps.resize(N+1, vector<int>(M+1, 0));
+    dp.resize(N+1, vector<int>(M+1, 0));
+    prefix.resize(N+1, vector<int>(M+1, 0));
+    for(int r=1; r<=N; r++) {
+        for(int c=1; c<=M; c++) {
+            int in; cin >> in;
+            maps[r][c] = in;
+        }
+    }
+
+    for(int r=1; r<=N; r++) {
+        for(int c=1; c<=M; c++) {
+            prefix[r][c] = maps[r][c] + prefix[r-1][c] + prefix[r][c-1] - prefix[r-1][c-1];
+        }
+    }
+    
+    cin >> H >> W >> sr >> sc >> fr >> fc;
+    dp[sr][sc] = 1; q.push({sr,sc}); 
+
+    bfs();
+    cout << ans-1;
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- Queue, Vector

### 알고리즘
- 그래프탐색(BFS)
- 누적합

### 시간복잡도
- 누적합 배열 계산: O(N × M) — 전체 지도에 대해 prefix sum을 미리 계산
- BFS 탐색: 각 칸 최대 한 번 방문하므로 O(N × M)
- possible 함수: 누적합을 이용해 직사각형 내 벽 유무를 O(1)에 판단하므로 BFS 내에서도 전체 시간은 O(N × M)

### 배운 점
- possible 함수 시간복잡도 최적화 하느라 죽는 줄 ..
    - 이게 범위 H,W 내로 돌면서 == 1 인지 체크하면 거의 N*M 만큼 돌아오는 칸 안에서 4방탐색할 때 H*W 를 다 돌아야 하니까 시간이 터졌다.
    - SOLVED: 누적합을 저장하여 r,c까지 오는데 벽이 몇 개 있었는지 더해서 prefix 배열에 저장한다.
        - possible 안에서 `가장 끝 벽 누적값 - HW범위 미포함 누적값`을 빼서 벽의 개수를 본다. 그 값이 0이면 거긴 벽이 없는 것
![알고리즘문제해결전략-39](https://github.com/user-attachments/assets/6ec9bb52-e13b-44e4-8049-c51f365e8922)

- 나머진 sr,sc부터 시작하는 무난한 BFS 문제로 풀었다.


