### PR TITLE
Solved: [그래프 탐색] BOJ_인구 이동 김나영

### DIFF
--- a/그래프 탐색/나영/BOJ_16234_인구 탐색.java
+++ b/그래프 탐색/나영/BOJ_16234_인구 탐색.java
@@ -1,0 +1,82 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int n, l, R, ans;
+    static boolean isS = true;
+    static int map [][];
+    static boolean visited[][];
+    static int dr[] = {-1, 0, 1, 0};
+    static int dc[] = {0, -1, 0, 1};
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+        
+        n = Integer.parseInt(st.nextToken());
+        l = Integer.parseInt(st.nextToken());
+        R = Integer.parseInt(st.nextToken());
+        map = new int [n][n];
+
+        for (int r = 0; r < n; r++) {
+            st = new StringTokenizer(br.readLine());
+            for (int c = 0; c < n; c++) {
+                map[r][c] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        while(isS) {
+            isS = false;
+            visited = new boolean [n][n];
+            for (int r = 0; r < n; r++) {
+                for (int c = 0; c < n; c++) {
+                    if (!visited[r][c]) bfs(r, c);
+                }
+            }
+            ans++;
+        }
+        
+        System.out.println(ans - 1);
+    }
+    
+    static void bfs(int r, int c) {
+        Queue<int []> que = new LinkedList<>();
+        List<int []> list = new ArrayList<>();
+        que.offer(new int [] {r, c});
+        list.add(new int [] {r, c});
+        visited[r][c] = true;
+        int sum = map[r][c];
+        int cnt = 1;
+
+        while (!que.isEmpty()) {
+            int [] q = que.poll();
+
+            for (int d = 0; d < 4; d++) {
+                int nr = q[0] + dr[d];
+                int nc = q[1] + dc[d];
+
+                if (check(nr, nc) && !visited[nr][nc] && Math.abs(map[q[0]][q[1]] - map[nr][nc]) >= l && Math.abs(map[q[0]][q[1]] - map[nr][nc]) <= R) {
+                    visited[nr][nc] = true;
+                    sum += map[nr][nc];
+                    cnt++;
+                    que.offer(new int [] {nr, nc});
+                    list.add(new int [] {nr, nc});
+                }
+            }
+        }
+
+        if (cnt != 1) {
+            isS = true;
+            int avg = sum / cnt;
+            for (int [] a : list) {
+                map[a[0]][a[1]] = avg;
+            }
+        }
+    }
+
+    static boolean check(int r, int c) {
+        return r >= 0 && r < n && c >= 0 && c < n;
+    }
+
+}


### PR DESCRIPTION
### 자료구조
- Queue
- 배열
- List

### 알고리즘
- 그래프 탐색
- BFS

### 시간복잡도
- 날짜는 최대 2000까지 나올 수 있음 => while문이 최대 2001까지 반복
- bfs() 메서드는 전체 n^2의 모든 좌표를 방문하며 연합이 존재하는지 확인 : O(n^2)
- 4방 탐색의 경우 상수이므로 제외
- 최종 시간복잡도 : O(2000 * n^2)

### 배운점
- 처음엔 visited2 배열, dfs() 메서드를 추가해 bfs 돌고 난 뒤의 연합국의 값을 전체 합의 평균으로 바꿔주려고 했음

```
static void dfs(int r, int c, int avg) {
        map[r][c] = avg;
        visited2[r][c] = true;

        for (int d = 0; d < 4; d++) {
            int nr = r + dr[d];
            int nc = c + dc[d];

            if (check(nr, nc) && visited[nr][nc] && !visited2[nr][nc]) {
                dfs(nr, nc, avg);
            }
        }
    }
```

- 그런데 visited 배열은 bfs 시 방문한 나라를 표시해주는 것이고, 날짜가 지날 때에만 초기화된다.
    -  이렇게 돌리면 다음 연합국을 찾고 해당 연합국의 값을 dfs로 변경할 때 연결되지 않았지만 이전에 방문한 타 연합국의 수도 바뀔 수 있었다(내가 int 배열로 1, 2 이렇게 연합국을 표시한 게 아니라 그냥 boolean으로 방문했는지 안했는지만 체크했기 때문에)
- 이런 바보같은,,, 그래서 그냥 list를 추가해 bfs에서 연합국이 있을 시 더해줬다.
- 이렇게 하면 cnt도 필요없습니다. 그냥 list.size()를 확인하면 되니까. (뺄 걸)
- 제발 시뮬레이션 잘 돌리고 코드 짜기~~!!! 이자시가