### PR TITLE
Solved: [그래프 탐색] BOJ_트리의 지름 홍지우

### DIFF
--- a/그래프 탐색/지우/BOJ_1967_트리의 지름.cpp
+++ b/그래프 탐색/지우/BOJ_1967_트리의 지름.cpp
@@ -1,0 +1,51 @@
+#include <iostream>
+#include <vector>
+
+using namespace std;
+
+int n;
+vector<vector<pair<int,int>>> adj;
+vector<bool> vis;
+int maxNode; int maxSum;
+
+void dfs(int node, int sum) {
+    if(maxSum < sum) {
+        maxSum = sum;
+        maxNode = node;
+    }
+
+    for(auto child : adj[node]) {
+        if(!vis[child.first]) {
+            vis[child.first] = true;
+            dfs(child.first, sum+child.second); 
+        }
+    }
+
+    return;
+}
+
+int main() {
+    ios::sync_with_stdio(0);
+    cin.tie(0);cout.tie(0);
+    
+    cin >> n;
+    adj.resize(n+1, vector<pair<int,int>>(0));
+    vis.resize(n+1, false);
+
+    for(int i=0; i<n-1; i++) {
+        int a, b, w; cin >> a >> b >> w;
+        adj[a].push_back({b,w});
+        adj[b].push_back({a,w});
+    }
+
+    vis[1] = true; 
+    dfs(1,0);
+    
+    vis.assign(n+1, false);
+    
+    vis[maxNode] = true;
+    dfs(maxNode,0);
+
+    cout << maxSum;
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- vector

### 알고리즘
- 그래프탐색(DFS)

### 시간복잡도
- DFS는 트리의 모든 정점을 1번씩 방문 → DFS 한 번당 시간복잡도는 O(n)
- DFS를 2번 실행하므로 총 시간복잡도는 O(2n) = O(n)
- 입력 처리와 인접 리스트 생성도 O(n) → 전체 알고리즘은 O(n)

### 배운 점
- 무방향은 곧 양방향이다
- 1부터 가장 깊고 모인 가중치가 제일 큰 애가 주인공이다
- 그 주인공으로부터 인접리스트를 따라 더이상 갈 수 없는 끝지점에 도달하는 dfs를 돌린다. 그 중 sum이 가장 큰 친구를 채택한다.