### PR TITLE
Solved: [그래프 탐색] BOJ_연구소 김나영

### DIFF
--- a/그래프 탐색/나영/BOJ_14502_연구소.java
+++ b/그래프 탐색/나영/BOJ_14502_연구소.java
@@ -1,0 +1,93 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int n, m, max;
+    static int map [][];
+    static boolean visited [][];
+    static int dr[] = {-1, 0, 1, 0};
+    static int dc[] = {0, -1, 0, 1};
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        map = new int [n][m];
+
+        for (int r = 0; r < n; r++) {
+            st = new StringTokenizer(br.readLine());
+            for (int c = 0; c < m; c++) {
+                map[r][c] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        dfs(0, 0, 0);
+        
+        System.out.println(max);
+    }
+
+    static void dfs(int r, int c, int cnt) {
+        if (cnt == 3) {
+            bfs();
+            return;
+        }
+
+        for (int nr = r; nr < n; nr++) {
+            for (int nc = 0; nc < m; nc++) {
+                if (nr == r && nc < c) continue;
+                if (map[nr][nc] == 0) {
+                    map[nr][nc] = 1;
+                    dfs(nr, nc, cnt+1);
+                    map[nr][nc] = 0;
+                }
+            }
+        }
+
+    }
+
+    static void bfs() {
+        visited = new boolean[n][m];
+        Queue<int[]> que = new LinkedList<>();
+        for (int r = 0; r < n; r++) {
+            for (int c = 0; c < m; c++) {
+                if(map[r][c] != 0) {
+                    visited[r][c] = true;
+                    if (map[r][c] == 2) que.offer(new int [] {r, c});
+                }
+            }
+        }
+
+        while (!que.isEmpty()) {
+            int [] q = que.poll();
+
+            for (int d = 0; d < 4; d++) {
+                int nr = q[0] + dr[d];
+                int nc = q[1] + dc[d];
+
+                if (check(nr, nc) && !visited[nr][nc] && map[nr][nc] == 0) {
+                    visited[nr][nc] = true;
+                    que.offer(new int[] {nr, nc});
+                }
+            }
+        }
+
+        find ();
+    }
+
+    static void find() {
+        int cnt = 0;
+        for (int r = 0; r < n; r++) {
+            for (int c = 0; c < m; c++) {
+                if(!visited[r][c]) cnt++;
+            }
+        }
+
+        max = Math.max(max, cnt);
+    }
+
+    static boolean check(int r, int c) {
+        return r >= 0 && r < n && c >= 0 && c < m;
+    }
+}


### PR DESCRIPTION
### 자료구조
- Queue
- 배열

### 알고리즘
- 그래프 탐색
- DFS
- BFS

### 시간복잡도
- 벽을 세우는 경우의 수

<img width="986" height="204" alt="image" src="https://github.com/user-attachments/assets/fa29e5d0-9432-4a14-8662-0292dee8f675" />

- 바이러스를 퍼뜨릴 때 시간복잡도 : O(n * m)
- 벽을 세우는 경우의 수 * 바이러스를 퍼뜨리기 : O(K^3 * n * m)

### 배운점
- 이 문제를 두 번이나 풀었음에도,, dfs 시 r과 c 관리를 제대로 하지 못함;
- 풀고 나서 gpt에게 물어봤는데, 

```
for (int i = idx; i < n * m; i++) {
        int r = i / m;
        int c = i % m;
    }
```

- 이렇게 인덱스 관리를 하는 방법도 있다.
- 난 걍 nr == r일 때 c가 nc보다 작은 지만 확인했다 => 작거나 같은지로 확인했다가 틀림,, 왜냐? 그럼 map[r][c]는 단 한번도 컨펌받지 못하고 continue 되기 때문,, 불쌍한 map[r][c] ㅠㅠ
- dfs로 벽을 3개 세우는 모든 경우의 수를 구한다
- 그렇게 벽을 총 3개 세우면 bfs로 바이러스 활동시키고 0의 개수를 구해 max값에 반영했습니다