### PR TITLE
Solved: [백트래킹] BOJ_N과 M (2) 홍지우

### DIFF
--- a/백트래킹/지우/BOJ_15650_N과M(2).cpp
+++ b/백트래킹/지우/BOJ_15650_N과M(2).cpp
@@ -1,0 +1,33 @@
+#include <iostream>
+#include <vector>
+
+using namespace std;
+
+int N, M;
+vector<bool> vis;
+
+void dfs(int idx, vector<int>& ans) {
+    if(ans.size() == M) {
+        for(auto c : ans) {
+            cout << c << " ";
+        }
+        cout << "\n";
+        return;
+    }
+
+    for(int i=idx; i<=N; i++) {
+        ans.push_back(i);
+        dfs(i+1, ans);
+        ans.pop_back();
+    }
+
+    return;
+}
+
+int main() {
+    cin >> N >> M; 
+    vector<int> ans(0);
+    
+    dfs(1,ans);
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터

### 알고리즘
- 백트래킹
- 조합

### 시간복잡도
- 1부터 N까지 숫자 중 M개를 오름차순으로 중복 없이 선택 → 조합(Combination)
- 시간복잡도는 O(N! / (M! × (N−M)!)) = O(NCM)
- N, M ≤ 8이므로 최악의 경우 O(70) 수준

### 배운 점
- 해당 조합 (1,2) (1,3) 이 유일하게끔 한다.
- 앞에서부터 포함하면서 그 뒤에 걸 고려하면 된다. 그럼 앞으로 돌아가지 않으니 중복되지 않는다.
- dfs() 1~N 돌려 이때 idx 넘겨! 수 포함해서 넘겨! / 포함 풀어!
    - idx ~ N 돌려 
        - 다음 idx+1 ~ N 돌려!
- 기저조건 if 모임조합개수 == M 이면 return