### PR TITLE
Solved: [그래프 탐색] BOJ_치즈 김나영

### DIFF
--- a/그래프 탐색/나영/BOJ_2636_치즈.java
+++ b/그래프 탐색/나영/BOJ_2636_치즈.java
@@ -1,0 +1,102 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class P {
+    int r, c;
+
+    public P (int r, int c) {
+        this.r = r;
+        this.c = c;
+    }
+}
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static int n, m, cnt, days, before;
+    static StringTokenizer st;
+    static int cheese[][];
+    static boolean visited[][];
+    static int dr[] = {-1, 0, 1, 0};
+    static int dc[] = {0, -1, 0, 1};
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        cheese = new int [n][m];
+
+        for (int r = 0; r < n; r++) {
+            st = new StringTokenizer(br.readLine());
+            for (int c = 0; c < m; c++) {
+                cheese[r][c] = Integer.parseInt(st.nextToken());
+                if (cheese[r][c] == 1) cnt++;
+            }
+        }
+
+        while (true) {
+            visited = new boolean [n][m];
+            bfs();
+
+            visited = new boolean [n][m];
+            before = cnt;
+            cnt = 0;
+            for (int r = 0; r < n; r++) {
+                for (int c = 0; c < m; c++) {
+                    if (cheese[r][c] == 1 && !visited[r][c]) {
+                        visited[r][c] = true;
+                        dfs(r, c);
+                    }
+                }
+            }
+            
+            days++;
+            if (cnt == 0) break;
+        }
+        
+        System.out.println(days);
+        System.out.println(before);
+    }
+
+    static void bfs() {
+        Queue<P> que = new LinkedList<>();
+        visited[0][0] = true;
+        que.offer(new P (0 ,0));
+
+        while (!que.isEmpty()) {
+            P p = que.poll();
+
+            for (int d = 0; d < 4; d++) {
+                int nr = p.r + dr[d];
+                int nc = p.c + dc[d];
+
+                if (check(nr, nc)) {
+                    if (cheese[nr][nc] == 1) {
+                        visited[nr][nc] = true;
+                        cheese[nr][nc] = 0;
+                    } else if (cheese[nr][nc] == 0 && !visited[nr][nc]) {
+                        que.offer(new P(nr, nc));
+                        visited[nr][nc] = true;
+                    }
+                }
+            }
+        }
+    }
+
+    static void dfs(int r, int c) {
+        cnt++;
+        
+        for (int d = 0; d < 4; d++) {
+            int nr = r + dr[d];
+            int nc = c + dc[d];
+
+            if (check(nr, nc) && cheese[nr][nc] == 1 && !visited[nr][nc]) {
+                visited[nr][nc] = true;
+                dfs(nr, nc);
+            }
+        }
+    }
+
+    static boolean check(int r, int c) {
+        return r >= 0 && r < n && c >= 0 && c < m;
+    }
+}


### PR DESCRIPTION
### 자료구조
- Queue
- 배열

### 알고리즘
- 그래프 탐색
- BFS
- DFS

### 시간복잡도
- BFS : 최악의 경우 모든 칸을 한 번씩 탐색 => O(n * m)
- DFS: 모든 칸 탐색하며 치즈의 개수를 구함 => O(n * m)
- days : n*m이 최악이지만, 앵간하면 n/2, n/3의 범위에서 끝날 듯
- 최종 시간복잡도 : O(n * m * days)

### 배운점
- 치즈가 감싸진 빈 공간은 접근하면 안되므로, BFS 시 1을 만나면 방문 처리하고 0으로 바꿔줬습니다.
- 그리고 0이며, 방문하지 않았으면 que에 넣습니당
- 치즈를 다 녹이면 before에 이전 치즈의 범위를 저장하고, DFS로 치즈의 범위를 확인합니다.
    - 치즈 맵 받을 때 cnt 초기화 안 해주면 95%에서 틀림
- 그리고 cnt 0이면 치즈 다 녹은 거니까 break~~

<img width="258" height="195" alt="image" src="https://github.com/user-attachments/assets/92b48fc8-36d8-4306-a03a-ced4f749ca57" />
