### PR TITLE
Solved: [그래프 탐색] BOJ_치즈 홍지우

### DIFF
--- a/그래프 탐색/지우/BOJ_2636_치즈.cpp
+++ b/그래프 탐색/지우/BOJ_2636_치즈.cpp
@@ -64,12 +64,6 @@ void bfs() {
 
         if(!wasCheese[r][c]) q.push({r,c});
     }
-
-    for(int r=0; r<N; r++) {
-        for(int c=0; c<M; c++) {
-            if(wasCheese[r][c]) maps[r][c] = 0;
-        }
-    }
     
     return;
 }


### PR DESCRIPTION
### 자료구조
- Vector, Queue

### 알고리즘
- 그래프탐색(BFS)

### 시간복잡도
- while(q.size() > 0)에서 최대 치즈 개수(최대 N×M)만큼 반복
- 각 bfs()마다 maps 전체를 확인하며 hole() + 치즈 탐색 진행 → O(N×M)
- 총 시간복잡도는 O((N×M) × (N×M)) = O((N×M)²) → N, M ≤ 100이면 약 10,000² = 💡 1억 → 통과 가능
=> days가 N*M이 최대라서..

### 배운 점
- 가운데 구멍은 안 녹힌다. ...
    - hole() : 겉 테두리는 무조건 0이므로 큐에 {0,0} 넣고 주변 0인 친구들을 다 vis 처리해서 겉 테두리만 고려하게끔 처리한다.
- bfs(): q.size를 미리 저장하고 한 해에 그만큼만 q에서 빼서 돌린다 (왜냐? q는 FIFO니까)
    - 주변이 vis[nr][nc]이면 치즈 있던 곳은 녹는다. 그때, wasCheese = True로 해주고 바로 break;
- 큐 돌리면서 maps[녹은치즈] = 0; 해주니까 안 돌아간다. 큐 돌리면서 안에 상태 바뀌면 안되는 듯
    - 마지막에 wasCheese 된 곳만 한번에 = 0 처리했다.