### PR TITLE
Solved: [그래프 탐색] BOJ_불! 홍지우

### DIFF
--- a/그래프 탐색/지우/BOJ_4179_불!.cpp
+++ b/그래프 탐색/지우/BOJ_4179_불!.cpp
@@ -1,0 +1,106 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+
+using namespace std;
+
+int R, C; int ans; int INF;
+vector<vector<int>> fireDP;
+vector<vector<int>> maps;
+vector<vector<bool>> vis;
+queue<vector<int>> jQ;
+queue<pair<int,int>> fQ;
+
+int dr[] = {-1,0,1,0};
+int dc[] = {0, 1, 0, -1};
+
+void spreadFire();
+void escape();
+bool inRange(int r, int c) {
+    return r>=0 && r<R && c>=0 && c<C;
+}
+
+int main() {
+    cin >> R >> C; ans = -1;
+    INF = 98765432;
+    maps.resize(R, vector<int>(C,0));
+    fireDP.resize(R, vector<int>(C,0)); 
+    vis.resize(R, vector<bool>(C,0));// J 위치 visited
+    for(int r=0; r<R; r++) {
+        string a; cin >> a;
+        for(int c=0; c<C; c++) {
+            
+            if(a[c] == '#') {
+                maps[r][c] = 2;
+                fireDP[r][c] = INF;
+            } 
+            else if(a[c] == 'F') {
+                maps[r][c] = 1;
+                fireDP[r][c] = 0;
+                fQ.push({r,c});
+            }
+            else if(a[c] == '.') {
+                maps[r][c] = 0;
+                fireDP[r][c] = INF;
+            }
+            else if(a[c] == 'J') {
+                maps[r][c] = 3;
+                fireDP[r][c] = INF;
+                jQ.push({r,c,0});
+                vis[r][c] = true;
+            }       
+        }
+    }
+
+    spreadFire();
+    escape();
+
+    if(ans == -1) {
+        cout << "IMPOSSIBLE";
+        return 0;
+    }
+    cout << ans;
+    return 0;
+}
+
+void spreadFire() {
+    while(!fQ.empty()) {      
+        auto[r,c] = fQ.front(); fQ.pop();
+
+        for(int d=0; d<4; d++) {
+            int nr = r + dr[d];
+            int nc = c + dc[d];
+
+            if(inRange(nr,nc) && maps[nr][nc] != 2 && fireDP[nr][nc] > fireDP[r][c]+1) {
+                fireDP[nr][nc] = fireDP[r][c]+1;
+                fQ.push({nr,nc});
+            }
+        }
+
+        
+    }
+}
+
+void escape() {
+    while(!jQ.empty()) {
+        vector<int> curr = jQ.front(); jQ.pop();
+        int r = curr[0];
+        int c = curr[1];
+        int time = curr[2];
+
+        if(r == 0 || c == 0 || r == R-1 || c == C-1) {
+            ans = time+1;
+            return;
+        }
+
+        for(int d=0; d<4; d++) {
+            int nr = r + dr[d];
+            int nc = c + dc[d];
+
+            if(inRange(nr, nc) && maps[nr][nc] != 2 && !vis[nr][nc] && fireDP[nr][nc] > time +1) {
+                vis[nr][nc] = true;
+                jQ.push({nr,nc, time+1});
+            }
+        }
+    }
+}


### PR DESCRIPTION
### 자료구조
- Vector, Queue

### 알고리즘
- 그래프탐색(BFS)

### 시간복잡도
- spreadFire()는 불이 퍼질 수 있는 모든 칸을 BFS로 탐색 → O(R × C)
- escape()는 지훈이의 모든 이동 경로를 BFS로 탐색 → O(R × C)
- 입력 처리 및 그 외 로직도 대부분 O(R × C) → 전체 시간복잡도는 O(R × C)

### 배운 점
- 불 처리 후 J 처리하는 DFS로 태울까 했는데 시초 엔딩일 것 같아서 선회함
- fireDP
    - 불이 도달하는 시점을 저장하는 저장소
    - 불이 도달하지 않은 곳은 INF로 채우기. 불 시작점 0(0초부터 거기였으니까). BFS를 돌리면서 다음 불의 장소(이전 장소 시간 +1) 
        - 불 방문x는 INF/ 불이 닿은 곳은(nr) dp[r]+1 / 닿을 곳은 dp[r]+1 보다 큰 곳이면 아직 불 안 닿은 곳이므로 가서 차지해준다.

➡️ 이러면 fireDP에는 불이 도착한 시간이 다 저장되어 있다.
여기 베이스에서 
- escape() 메소드 : J가 도달한 시점은 '불이 도달한 시점보다 더 작아야 함'
    - 조건을 달고 그에 충족되는 위치만 q에 넣고 돌리면
    - 결국 Q에 남아서 가장자리에 도착하는 아이는 탈출한 친구이다.