### PR TITLE
Solved: [그래프 탐색] BOJ_텀 프로젝트 홍지우

### DIFF
--- a/그래프 탐색/지우/BOJ_9466_텀 프로젝트.cpp
+++ b/그래프 탐색/지우/BOJ_9466_텀 프로젝트.cpp
@@ -1,0 +1,55 @@
+#include <iostream>
+#include <unordered_set>
+#include <vector>
+
+using namespace std;
+
+int T; int N; int cnt;
+vector<int> adj;
+vector<bool> vis;
+vector<bool> done;
+
+void dfs(int currStu);
+
+int main() {
+    cin >> T;
+    for(int tc=1; tc<=T; tc++) {
+        cin >> N; cnt = 0;
+        adj.assign(N+1,0);
+        vis.assign(N+1,false);
+        done.assign(N+1,false); // 완전히 탐색이 끝났는지 확인하는 용도
+        
+
+        for(int i=1; i<=N; i++) {
+            cin >> adj[i];
+        }
+
+        for(int i=1; i<=N; i++) {
+            if(!vis[i]) {
+                dfs(i);
+            }
+        }
+        cout << N - cnt << "\n";
+    }
+    
+    return 0;
+}
+
+void dfs(int currStu) {
+
+    vis[currStu] = true;
+    int nxt = adj[currStu]; 
+
+    if(!vis[nxt]) {
+        dfs(nxt);
+    }
+    else if(!done[nxt]) { // '이미 발견함 즉, currStu 포함 사이클 발생 + '이전 경로에서 다 돌아본 적 없는 친구'
+        for(int i = nxt; i != currStu; i = adj[i]) { // 인접 -> 인접으로 사이클 돌기 
+            cnt++;
+        }
+        cnt++;
+    }
+    
+    done[currStu] = true; // 이 노드 탐색 완료! 
+    return;
+}


### PR DESCRIPTION
### 자료구조
- Vector

### 알고리즘
- DFS

### 시간복잡도
- 각 테스트케이스마다 N개의 학생에 대해 DFS를 최대 1번씩만 수행 → O(N)
- 각 DFS는 그래프를 따라가며 한 번 방문한 노드는 done 체크로 중복 방문하지 않음
- 전체 테스트케이스에 대해 **O(∑N)**의 시간복잡도 ⇒ 최대 100,000

### 배운 점
[1차 시도] - 시간초과
- O(N^2) 돌면서 터짐
- 바깥에서 임의의 점부터 start를 갖고 Dfs를 돌린 후, start와 마주하면 사이클 판단함.
- 한 번 사이클 판정이 된 것도 다시 판정해야 하는 문제가 있음

[Solved]
- 안 터지려면 '한 번만' 돌아야 한다.
- 어떻게? 
    - 어디든 지나가 본 곳은 다 vis 처리. 
    - 한 학생의 dfs가 다 끝나는 지점에 done[]을 설치해서 이미 판단이 끝난 친구는 다시 돌아가지 않게끔 함
예를 들어,
1 -> 2 -> 2 이런 상황이다. 
1로 들어갔는데 2-2 사이클 생기고 '2번'만 팀이 되는 상황
dfs(1) 시작 -> nxt 2 -> dfs(2) -> nxt 2 (이미 방문함/ 아직 dfs(2) 안 끝남) -> 인접 사이클 개수 판단 cnt = 1 -> done[2] + dfs(2) 끝 -> done[1] + dfs(1) 끝

- 저번에 이해 안됐던 For문 다시 정신을 가다듬고 이해해봤다..
```
for(int i = nxt; i != currStu; i = adj[i]) { // 인접 -> 인접으로 사이클 돌기 
            cnt++;
        }
```
1(1)-> 2-> 3 -> 1(2)
currStu = 3/ nxt = 1(2)
1(2) -> 2 -> 3:어랏!! `i != currStu` 스톱스톱!!!
```