### PR TITLE
Solved: [그래프 탐색] BOJ_움직이는 미로 탈출 홍지우

### DIFF
--- a/그래프 탐색/지우/BOJ_16954_움직이는 미로 탈출.cpp
+++ b/그래프 탐색/지우/BOJ_16954_움직이는 미로 탈출.cpp
@@ -1,0 +1,88 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+
+using namespace std;
+
+int ans = 0;
+vector<vector<vector<int>>> maps;
+queue<vector<int>> q;
+queue<vector<int>> wq;
+vector<vector<vector<bool>>> vis;
+
+int dr[] = {1, 0, -1, 0, -1, -1, 1 ,1};
+int dc[] = {0, 1, 0, -1, -1, 1, -1, 1};
+
+bool inRange(int r, int c) {
+    return r>=0 && r<8 && c>=0 && c<8;
+}
+
+void bfs() {
+    while(!q.empty()) {
+
+        int wSize = wq.size();
+        while(wSize--) {
+            vector<int> curr = wq.front(); wq.pop();
+            int r = curr[0]; int c = curr[1];
+            int time = curr[2];
+            
+            int nr = r + dr[0];
+            int nc = c + dc[0];
+            if(inRange(nr,nc)) {
+                maps[nr][nc][time+1] = 1; 
+                wq.push({nr, nc, time+1});
+            }
+        }
+
+        int cSize = q.size();
+        while(cSize--) {
+            vector<int> curr = q.front(); q.pop();
+            int r = curr[0]; int c = curr[1];
+            int time = curr[2];
+
+            if(r == 0 && c == 7) {
+                ans = 1;
+                return;
+            }
+
+            for(int d=0; d<8; d++) {
+                int nr = r + dr[d]; int nc = c + dc[d];
+                if(inRange(nr, nc) && !vis[nr][nc][time+1] && maps[nr][nc][time] != 1 && maps[nr][nc][time+1] != 1) { 
+                                                                //지금 time에 벽이 없어야 갈 수 있다 && 다음에 넘어갈 곳도 벽도 없어야 함
+                    vis[nr][nc][time+1] = true;
+                    q.push({nr,nc,time+1});
+                }
+            }
+            if(!vis[r][c][time+1] && maps[r][c][time+1] != 1) {
+                vis[r][c][time+1] = true;
+                q.push({r,c,time+1});
+            }
+        }
+
+        
+    }
+}
+
+int main() {
+    maps.resize(8, vector<vector<int>>(8,vector<int>(66,0))); // r,c, 걸린 시간
+    vis.resize(8, vector<vector<bool>>(8,vector<bool>(66,false)));
+    
+    // 8 * 8
+    for(int r=0; r<8; r++) {
+        string a; cin >> a;
+        for(int c=0; c<8; c++) {
+            if(a[c] == '.') {
+                maps[r][c][1] = 0;
+            } else {
+                maps[r][c][1] = 1;
+                wq.push({r,c,1});
+            }
+        }
+    }
+
+    vis[7][0][1] = true;
+    q.push({7,0,1});
+    bfs();
+    cout << ans;
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- Queue, Vector

### 알고리즘
- 그래프탐색(BFS)

### 시간복잡도
- 플레이어와 벽의 이동은 시간에 따라 진행되며, 최대 64턴(또는 66턴)까지 8×8 격자를 방문 가능 → O(64 × 64) = O(4096) 수준의 시간복잡도.
- 각 시간마다 모든 위치에 대해 이동 여부 검사(8방향 + 제자리) 및 큐 삽입 → O(T × N² × 9) → O(66 × 64 × 9) = O(≈ 38,000).
- 공간복잡도는 maps[8][8][66], vis[8][8][66] 구조로 → O(N² × T) = O(64 × 66) = O(4224).

### 배운 점
- 문제를 잘 읽자 "현재 위치에 서 있을 수 있다."
- 핵심: 시간마다 벽의 상태가 다르다
💡 차원을 달리해야 하는 문제다..!
    - 아 이래서 8*8 배열 줬구나 메모리 제한 때문에

[1차 시도]  
 - Maps에 DP 처럼 maps[r][c] = 벽이 거기까지 간데 걸린 시간 이렇게 저장하고
 - maps를 기준으로 욱제(r,c,time)이랑 비교해서 
     - 욱제시간        != map[nr][nc]  // 지금 time에 벽이 원래 있으니까. 그땐 그냥 막혀서 못 가는 상황
     - 욱제시간 + 1  !=  map[nr][nc] // 지금은 벽이 아니었는데, 옮겨갔더니 다음에(time+1) 벽이 내려와서 못 가는 상황.
     - (+) 안 움직이는 경우 - map[r][c] 라는 벽 시간이 욱제의time+1 이랑 다를 때 갈 수 있다.


🧼 내 로직대로라면 map에 하나의 벽에 대한 이전시간, 이후시간이 잘 적혀있어야 하는데 
🌋 벽이 만약 위 아래로 붙어있을 경우, 아래 있는 벽에 대한 기록을 위에 있는 벽이 지움으로써 틀리게 된다.


[SOLVED]
- 이전 로직과 흐름은 같은데 (map[r][c] = time 🙅) => (map[r][c][time] = 벽 1,0 🙆 ) 이렇게 바꿨다
- 욱제 vis도 [r][c][time] 으로 나누어 시간별로 간 곳 안 간 곳을 나눌 수 있게 했다.
- 근데 생각해보니까 이 방식으로 하면 미리 wall bfs 돌려놓고 나중에 욱제bfs 돌려도 될 듯 size 따로 빼서 안해도 되고 (그치만 리팩토링 할 기력이 없음 헤헤)
