### PR TITLE
Solved: [그래프 탐색] BOJ_텔레포트 정거장 홍지우

### DIFF
--- a/그래프 탐색/지우/BOJ_18232_텔레포트 정거장.cpp
+++ b/그래프 탐색/지우/BOJ_18232_텔레포트 정거장.cpp
@@ -1,0 +1,61 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+#include <unordered_set>
+
+using namespace std;
+
+long long N, M, S, E;
+vector<vector<long long>> adj;
+queue<pair<long long,long long>> q; // 정점, 시간
+unordered_set<long long> vis;
+
+long long bfs() {
+    vis.insert(S);
+    q.push({S,0});
+
+    while(!q.empty()) {
+        auto[curr, time] = q.front(); q.pop();
+
+        if(curr == E) {
+            return time;
+        }
+
+        for(auto nxt : adj[curr]) {
+            if(!vis.count(nxt)) {
+                vis.insert(nxt);
+                q.push({nxt, time+1});
+            }
+        }
+
+        if(curr-1 > 0 && !vis.count(curr-1)) {
+            vis.insert(curr-1);
+            q.push({curr-1, time+1});
+        }
+
+        if(curr+1 <= N &&!vis.count(curr+1)) {
+            vis.insert(curr+1);
+            q.push({curr+1, time+1});
+        }
+    }
+
+    return -1;
+}
+
+int main() {
+    cin.tie(0); cout.tie(0); ios::sync_with_stdio(0);
+    cin >> N >> M >> S >> E;
+    adj.resize(N+1, vector<long long>(0));
+
+    for(int m=0; m<M; m++) {
+        long long a, b;
+        cin >> a >> b;
+
+        adj[a].push_back(b);
+        adj[b].push_back(a);
+    }
+
+    cout << bfs();
+    
+    return 0;
+}


### PR DESCRIPTION
### 자료구조 
- 벡터, 큐, Unordered_set

### 알고리즘
- 그래프탐색(BFS)

### 시간복잡도
- BFS로 각 노드를 한 번만 방문하므로 O(N)
- 각 간선은 양방향으로 M개이므로, 인접리스트 순회는 O(M)
- 추가로 curr-1, curr+1도 최대 N번만 큐에 들어가므로 전체 BFS는 O(N + M)

### 배운 점
- 노드가 1~N까지인거 까먹고 curr -1 > 0 , curr + 1 <= N 조건을 안 넣어줬더니 outOfBound 런타임에러 떴다


| 조건                                                         | 자료형 결정 기준             |
|--------------------------------------------------------------|------------------------------|
| 문제에서 `N`, `M` ≤ 10⁶ ~ 10⁷ 이하                           | `int`로 충분합니다           |
| 문제에서 `N`, `M` ≥ 10⁹ 이상                                 | `long long`이 필요합니다     |
| 정점 번호가 `curr + 1`, `curr - 1` 등으로 **10⁹ 이상까지 증가 가능** | `long long`이 필요합니다     |


- 꼭 Long long을 쓸 필요는 없었는데 그냥 이전에 데였던 기억이 나서 longlong으로 다 처리했다.
- set말고 visited[] 써도 됐었는데(N이 주어지기 때문) 어차피 Unordered_set이라 O(1)에 가능하니까 이걸 택했다