### PR TITLE
Solved: [그래프 탐색] BOJ_모양 만들기 홍지우

### DIFF
--- a/그래프 탐색/지우/BOJ_16932_모양 만들기.cpp
+++ b/그래프 탐색/지우/BOJ_16932_모양 만들기.cpp
@@ -1,0 +1,91 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+#include <set>
+
+using namespace std;
+
+int N, M;
+vector<vector<int>> maps; vector<vector<int>> vis;
+vector<vector<int>> groupSizes; vector<vector<int>> groupNames;
+queue<pair<int,int>> q; queue<pair<int,int>> q2;
+int gName = 0; int maxSize = 0;
+
+int dr[] = {-1, 0, 1, 0};
+int dc[] = {0, 1, 0, -1};
+
+bool inRange(int r, int c){
+    return r>=0 && r<N && c>=0 && c<M;
+}
+
+void bfs() {
+    gName++;
+    int cnt = 0;
+
+    while(!q.empty()) {
+        auto[r,c] = q.front(); q.pop();
+        groupNames[r][c] = gName;
+        cnt++;
+        q2.push({r,c});
+
+        for(int d=0; d<4; d++) {
+            int nr = r + dr[d];
+            int nc = c + dc[d];
+            if(inRange(nr,nc) && !vis[nr][nc] && maps[nr][nc] == 1) {
+                vis[nr][nc] = true;
+                q.push({nr,nc});
+            }
+        }
+    }
+
+    while(!q2.empty()) {
+        auto[r,c] = q2.front(); q2.pop();
+        groupSizes[r][c] = cnt;
+    }
+}
+
+int main() {
+    cin.tie(0); cout.tie(0); ios::sync_with_stdio(0);
+    cin >> N >> M;
+    maps.resize(N, vector<int>(M,0));
+    vis.resize(N, vector<int>(M,0));
+    groupSizes.resize(N, vector<int>(M,0));
+    groupNames.resize(N, vector<int>(M,0));
+
+    for(int r=0; r<N; r++) {
+        for(int c=0; c<M; c++) {
+            cin >> maps[r][c];
+        }
+    }
+    
+    for(int r=0; r<N; r++) {
+        for(int c=0; c<M; c++) {
+            if(!vis[r][c] && maps[r][c] == 1) {
+                vis[r][c] = true;
+                q.push({r,c});
+                bfs();
+            }
+        }
+    }
+
+    for(int r=0; r<N; r++) {
+        for(int c=0; c<M; c++) {
+            
+            if(maps[r][c] == 0) {
+                int tmp = 0; set<int> s;
+                for(int d=0; d<4; d++) {
+                    int nr = r + dr[d]; int nc = c + dc[d];
+                    if(inRange(nr,nc) && maps[nr][nc] == 1 && !s.count(groupNames[nr][nc])) {
+                        tmp += groupSizes[nr][nc];
+                        s.insert(groupNames[nr][nc]);
+                    }
+                }
+                maxSize = max(maxSize, tmp);
+            }
+            
+        }
+    }
+    
+    cout << maxSize +1;
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터, 큐, 셋

### 알고리즘
- 그래프탐색(BFS)

### 시간복잡도
- 처음 N × M 격자를 한 번씩 탐색하여 BFS로 각 그룹을 나누고 크기 계산 → O(N × M)
- 각 칸에 대해 상하좌우 인접한 그룹의 크기를 더함 → 매 칸마다 최대 4번의 인접 체크로 O(N × M)
- 전체 시간복잡도는 O(N × M)

### 배운 점
업데이트를 계속 할 필요는 없으니까 모든 정보가 저장된 배열을 활용했다.
1. 초기 map에서 bfs() 돌리기
    - groupNames[][] 에 같은 그룹이면 같은 그룹 name을 갖도록 한다.
    - groupSizes[][] 에 총 그룹의 사이즈를 넣는다.
2. 정방향 순회하면서 0 인 부분을 발견하면 4방탐색한다.
    - 각 0 칸 에서의 인접한 칸들의 groupSizes[][]를 다 더한다. (근데 다 다른 그룹에 속한 애들의 size여야 함. - 그래서 set씀_이미 방문한 GroupName은 안되게끔!!!) 