### PR TITLE
Solved: [그래프 탐색] BOJ_원 이동하기 1 홍지우

### DIFF
--- a/그래프 탐색/지우/BOJ_22946_원 이동하기 1.cpp
+++ b/그래프 탐색/지우/BOJ_22946_원 이동하기 1.cpp
@@ -1,0 +1,97 @@
+#include <iostream>
+#include <vector>
+#include <tuple>
+#include <algorithm>
+#include <cmath>
+
+using namespace std;
+
+int N; int ans = 0;
+vector<tuple<int,int,int>> inputs;
+vector<vector<int>> trees;
+vector<bool> vis;
+
+bool cmp(tuple<int,int,int> a, tuple<int,int,int> b) {
+    return get<2>(a) < get<2>(b); // 오름차순
+}
+
+bool inOrOut(tuple<int,int,int> a, tuple<int,int,int> b) {
+    auto [x1, y1, r1] = a;
+    auto [x2, y2, r2] = b;
+
+    long double d1 = x2-x1;
+    long double d2 = y2-y1;
+    long double d = sqrt(d1*d1 + d2*d2); // pow(,2)는 Float 기반 연산이라 이게 더 안정적이라고 함 
+
+    // 두 원 서로 
+    if(d==0 || d < abs(r1-r2)) return 1; // 내부
+    return 0; // 외부
+}
+
+void Connect(int curr) {
+    int nxt = curr + 1;
+    bool alreadySeen = false;
+
+    while(nxt < inputs.size()) {
+        if(inOrOut(inputs[curr], inputs[nxt])) { // 서로 내부임!
+            if(!trees[nxt].empty()) alreadySeen = true; // 이미 저번에 다 돌아서 그 다음 연결 노드 다 담았음 
+            
+            trees[curr].push_back(nxt);
+            trees[nxt].push_back(curr);
+
+            curr = nxt; // 이제 curr이었던 애 부모부터 연결관계 확인해보자
+        }
+
+        if(alreadySeen) return;
+        nxt++;
+    }
+}
+
+int dfs(int node, int depth) {
+    int maxDepth = depth;
+    for(auto nxt : trees[node]) {
+        if(!vis[nxt]) {
+            vis[nxt] = true;
+            maxDepth = max(maxDepth, dfs(nxt, depth+1));
+            vis[nxt] = false;
+        }
+    }
+    return maxDepth;
+}
+ 
+int main() {
+    cin >> N;
+    inputs.clear();
+    trees.resize(N+1);
+    vis.resize(N+1, false);
+    tuple<int,int,int> 좌표평면 = make_tuple(0,0,20000000); // 훨씬 크게 만들어주기
+    inputs.push_back(좌표평면);
+
+    for(int i=0; i<N; i++) {
+        int x, y, r;
+        cin >> x >> y >> r;
+
+        tuple<int,int,int> input = make_tuple(x,y,r);
+        inputs.push_back(input);
+    }
+
+    sort(inputs.begin(), inputs.end(), cmp);
+
+    // 처음부터 끝까지 포함관계끼리 트리로 연결해보기 
+    for(int i=0; i<inputs.size(); i++) {
+        if(trees[i].empty()) {
+            Connect(i);
+        }
+    }
+
+    // DFS로 조건에 알맞게 제일 깊은 depth를 구해라
+    for(int i=0; i<inputs.size(); i++) {
+        vis[i] = true;
+        ans = max(ans, dfs(i,0));
+        vis[i] = false;
+    }
+
+    cout << ans;
+    
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터, 튜플

### 알고리즘
- DFS
- 구현..?

### 시간복잡도
- 입력 정렬: sort(inputs.begin(), inputs.end()) → O(N log N)
- 트리 연결 (Connect 함수): 각 원에 대해 O(N) 번 탐색할 수 있으므로 최악의 경우 O(N²)
- DFS 수행: 노드마다 DFS 최대 깊이 탐색 → O(N²)

🔍 총 시간복잡도: O(N²)
N ≤ 5000이므로, O(N²) = 약 25,000,000 → 시간 제한 내 통과 가능.
만약 N이 10만 이상이었다면 시간초과가 발생할 수 있는 구조입니다.

### 배운 점
- ... ㅎ 
- 풀이법
    - 트리 : 두 원이 서로 내부에 있다면 연결
    - DFS를 임의의 노드부터 시작하여 트리(like 인접리스트)를 따라가며 가장 깊은 depth를 구한다.

- 원을 직접 표현하는 것이 아닌, 포함 관계로 보며 인접 리스트로 구현하는 아이디어가 중요했던 문제
- sort(시작, 끝, bool타입의메서드) 처음 써봤다.
- ``` bool cmp(tuple<int,int,int> a, tuple<int,int,int> b) {
    return get<2>(a) < get<2>(b); // 오름차순
}
```
- inOrOut
    - 미세한 소수점 차이의 거리로 달라질 수도 있어서 long long이 아닌 long double로 해줬다
    - pow(,2)는 추가 연산시간이 들기도 하고 float 기반 결과 산출이라고 하여 x*x 형태로 표현해줬다.