### PR TITLE
Solved: [백트래킹] BOJ_N과 M (5) 홍지우

### DIFF
--- a/백트래킹/지우/BOJ_15654_N과 M (5).cpp
+++ b/백트래킹/지우/BOJ_15654_N과 M (5).cpp
@@ -1,0 +1,51 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+
+int N, M;
+vector<int> nums;
+vector<int> picks;
+vector<bool> vis;
+
+void dfs(int sIdx) {
+
+    if(sIdx == M) {
+        for(auto num : picks) {
+            cout << num << " ";
+        }
+        cout << "\n";
+        return;
+    }
+
+    for(int i=0; i<N; i++) {
+        if(!vis[i]) {
+            vis[i] = true;
+            picks.push_back(nums[i]);
+            
+            dfs(sIdx+1);
+            
+            vis[i] = false;
+            picks.pop_back();
+        }
+    }
+
+    return;
+}
+
+
+int main() {
+    cin.tie(0); cout.tie(0); ios::sync_with_stdio(0);
+    cin >> N >> M;
+    nums.resize(N,0);
+    vis.resize(N,false);
+    
+    for(int i=0; i<N; i++) {
+        cin >> nums[i];
+    }
+
+    sort(nums.begin(), nums.end());
+    dfs(0);
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터

### 알고리즘
- 백트래킹_순열

### 시간복잡도
- 가능한 순열의 개수는 P(N, M) = N! / (N - M)!
- 각 순열마다 출력 비용이 **O(M)**이므로, 총 출력 비용은 O(M × P(N, M))
- 따라서 총 시간복잡도는 O(M × N! / (N - M)!)

### 배운 점
- 하나의 자리에 0~N-1의 자리까지 돌면서 다 올 수 있다. (이미 등장한 것 제외)
- vis처럼 picks도 각 dfs 호출마다 다르게 관리할 수 있으므로 전역에 선언하고 기저조건 만족 시 다 picks에 들어간 친구들을 출력했다.

