### PR TITLE
Solved: [백트래킹] BOJ_N과 M (4) 홍지우

### DIFF
--- a/백트래킹/지우/BOJ_15652_N과 M (4).cpp
+++ b/백트래킹/지우/BOJ_15652_N과 M (4).cpp
@@ -1,0 +1,33 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+
+int N, M;
+vector<int> picks;
+
+void dfs(int s, int sIdx) {
+    if(sIdx == M) {
+        for(auto num : picks) {
+            cout << num << " ";
+        }
+        cout << "\n";
+        return;
+    }
+
+    for(int i=s; i<=N; i++) {
+        picks.push_back(i);
+        dfs(i, sIdx+1);
+        picks.pop_back();
+    }
+    return;
+}
+
+int main() {
+    cin.tie(0); cout.tie(0); ios::sync_with_stdio(0);
+    cin >> N >> M;
+    
+    dfs(1, 0);
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터

### 알고리즘
- 백트래킹(순열)

### 시간복잡도
- dfs(i, sIdx+1) 호출에서 i 이상만 재귀 호출되므로, 중복을 허용한 비내림차순 조합 생성
- 전체 조합 수는 N 개 중 M개를 중복 허용하여 비내림차순으로 고르기 = 조합(중복 허용) = (N+M−1)C(M)
- 따라서 시간복잡도는 O((N+M−1)C(M)), 출력 포함 시 **O(M × (N+M−1)C(M))**입니다.

### 배운 점
- 전에 등장한 것을 기준으로 그거부터 ~ N까지 나와야 했던 문제
- dfs()에서 이전 수(s)를 넘김으로써 s기준부터 ~ N 까지 picks에 담길 수 있도록 해줬다.
```
dfs(1, 0)
├── i=1 → picks: [1]
│   └── dfs(1, 1)
│       ├── i=1 → picks: [1, 1] ✅ 출력
│       ├── i=2 → picks: [1, 2] ✅ 출력
│       └── i=3 → picks: [1, 3] ✅ 출력
├── i=2 → picks: [2]
│   └── dfs(2, 1)
│       ├── i=2 → picks: [2, 2] ✅ 출력
│       └── i=3 → picks: [2, 3] ✅ 출력
└── i=3 → picks: [3]
    └── dfs(3, 1)
        └── i=3 → picks: [3, 3] ✅ 출력
```