### PR TITLE
Solved: [백트래킹] BOJ_N과 M (8) 홍지우

### DIFF
--- a/백트래킹/지우/BOJ_15657_N과 M (8).cpp
+++ b/백트래킹/지우/BOJ_15657_N과 M (8).cpp
@@ -1,0 +1,40 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+
+int N, M;
+vector<int> nums;
+vector<int> picks;
+
+void dfs(int s, int sIdx) {
+    if(sIdx == M) {
+        for(auto num : picks) {
+            cout << num << " ";
+        }
+        cout << "\n";
+        return;
+    }
+
+    for(int i=s; i<N; i++) {
+        picks.push_back(nums[i]);
+        dfs(i, sIdx+1);
+        picks.pop_back();
+    }
+    return;
+}
+
+int main() {
+    cin.tie(0); cout.tie(0); ios::sync_with_stdio(0);
+    cin >> N >> M;
+    nums.resize(N,0);
+    for(int i=0; i<N; i++) {
+        cin >> nums[i];
+    }
+
+    sort(nums.begin(), nums.end());
+    
+    dfs(0, 0);
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터

### 알고리즘
- 백트래킹
- 순열

### 시간복잡도
- 깊이가 M, 각 깊이마다 선택지는 최대 N개 → O(N^M)
- dfs(i, sIdx+1) 호출로 인해 중복 허용 없이 비내림차순 조합 탐색
- 따라서 전체 시간복잡도는 **O(조합 수 * M) = O( (N+M-1)C(M) * M )**에 가까움 (출력 포함)

### 배운 점
- (4) 와 같은 문제
- 이전에 가져온 수부터 N까지 담으면서 업데이트