### PR TITLE
Solved: [백트래킹] BOJ_부분수열의 합 김나영

### DIFF
--- a/백트래킹/나영/BOJ_1182_부분수열의 합.java
+++ b/백트래킹/나영/BOJ_1182_부분수열의 합.java
@@ -1,0 +1,33 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int n, s, ans;
+    static int [] arr;
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        s = Integer.parseInt(st.nextToken());
+        arr = new int[n];
+        
+        st = new StringTokenizer(br.readLine());
+
+        for (int i = 0; i < n; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        dfs(0, 0);
+        
+        System.out.println(ans);
+    }
+
+    static void dfs(int start, int sum) {
+        if (start > 0 && sum == s) ans++;
+        for (int i = start; i < n; i++) {
+            dfs(i+1, sum + arr[i]);
+        }
+    }
+}


### PR DESCRIPTION
### 자료구조
- 배열

### 알고리즘
- 백트래킹

### 시간복잡도
- 각 원소에 대한 모든 부분집합을 추출
- 각 원소들은 선택할지, 안 할지 두 가지 선택지가 생김
- 최종 시간복잡도 : **O(2^n)**

### 배운점
- 부분집합을 전부 선택하는,,데 공집합은 빼야 했던 문제
- 그래서 return 조건에서 start가 0인 경우는 공집합이므로 제외했고, 그 외애는 sum이 s와 같을 경우 ans를 더해주었다.