### PR TITLE
Solved: [백트래킹] BOJ_부분수열의 합 홍지우

### DIFF
--- a/백트래킹/지우/BOJ_1182_부분수열의 합.cpp
+++ b/백트래킹/지우/BOJ_1182_부분수열의 합.cpp
@@ -1,0 +1,34 @@
+#include <iostream>
+#include <vector>
+
+using namespace std;
+
+int N, S;
+int ans = 0;
+vector<int> nums;
+
+void dfs(int sum, int idx) {
+    if(idx == N) {
+        if(sum == S) ans++;
+        return;
+    }
+
+    dfs(sum + nums[idx], idx+1);
+    dfs(sum, idx+1);
+}
+
+int main() {
+    cin >> N >> S;
+    nums.resize(N,0);
+
+    for(int i=0; i<N; i++) {
+        cin >> nums[i];
+    }
+
+    
+    dfs(0, 0);
+    if(S == 0) ans--;
+    cout << ans;
+    
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터

### 알고리즘
- 백트래킹

### 시간복잡도
1. 원소마다 "포함" / "비포함" 두 가지 선택 → 전체 경우의 수는 2^N
2. dfs는 최대 2^N번 호출됨 → 시간복잡도는 **O(2^N)**
3. N ≤ 20 이므로, 최악의 경우 2^20 ≒ 1,000,000 → 시간 내 충분히 가능

### 배운 점
- 부분수열 = 조합의 문제. 순서를 생각하지 않아도 된다.
- 포함? 비포함? 만 고르면 됐다.
- 모든 원소를 선택하지 않는 경우도 있으니, S==0이면 ans에서 하나 빼줬다.