### PR TITLE
Solved: [백트래킹] BOJ_N과 M (9) 홍지우

### DIFF
--- a/백트래킹/지우/BOJ_15663_N과 M (9).cpp
+++ b/백트래킹/지우/BOJ_15663_N과 M (9).cpp
@@ -1,0 +1,49 @@
+#include <iostream>
+#include <vector>
+#include <set>
+#include <algorithm>
+
+using namespace std;
+
+int N, M;
+vector<int> nums;
+vector<int> picks;
+vector<bool> vis;
+set<string> sets;
+
+void dfs(int pIdx) {
+    if(pIdx == M) {
+        string s = "";
+        for(int i=0; i<M; i++) {
+            s += to_string(picks[i]) + " ";
+        }
+        if(!sets.count(s)) {
+            sets.insert(s);
+            cout << s << "\n";
+        }
+        return;
+    }
+    
+    for(int i=0; i<N; i++) {
+        if(vis[i]) continue;
+        vis[i] = true;
+        picks.push_back(nums[i]);
+        dfs(pIdx+1);
+        vis[i] = false;
+        picks.pop_back();
+    }
+}
+
+int main() {
+    cin.tie(0); cout.tie(0); ios::sync_with_stdio(0);
+    cin >> N >> M;
+    nums.resize(N,0);
+    vis.resize(N,false);
+    for(int i=0; i<N; i++) {
+        cin >> nums[i];
+    }
+    sort(nums.begin(), nums.end());
+    dfs(0);
+    
+    return 0;
+}

--- a/백트래킹/지우/BOJ_15663_N과 M (9)_2.cpp
+++ b/백트래킹/지우/BOJ_15663_N과 M (9)_2.cpp
@@ -1,0 +1,46 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+
+int N, M;
+vector<int> nums;
+vector<int> picks;
+vector<bool> vis;
+
+void dfs(int pIdx) {
+    if(pIdx == M) {
+        for(int i=0; i<M; i++) {
+            cout << picks[i] << " ";
+        }
+        cout << "\n";
+        return;
+    }
+
+    int pre = -1; // 같은 레벨에서 같은 숫자를 중복으로 사용하지 않도록 이전 값 저장!
+    
+    for(int i=0; i<N; i++) {
+        if(vis[i] || pre == nums[i]) continue;
+        vis[i] = true;
+        picks.push_back(nums[i]);
+        dfs(pIdx+1);
+        vis[i] = false;
+        picks.pop_back();
+        pre = nums[i]; // 현재 사용된 값 저장 
+    }
+}
+
+int main() {
+    cin.tie(0); cout.tie(0); ios::sync_with_stdio(0);
+    cin >> N >> M;
+    nums.resize(N,0);
+    vis.resize(N,false);
+    for(int i=0; i<N; i++) {
+        cin >> nums[i];
+    }
+    sort(nums.begin(), nums.end());
+    dfs(0);
+    
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터

### 알고리즘
- 백트래킹

### 시간 복잡도
- 1번 코드 (set 사용)
1. 가능한 순열 수: O(N!) — 각 수마다 한 번씩만 사용
2. 각 순열마다 문자열 생성 및 set 삽입/탐색: O(M log K), K는 현재 set 크기
3. 전체 시간복잡도: O(N! × M log N!)

- 2번 코드 (pre 중복 방지)
1. 중복이 제거된 경우만 탐색하므로 분기 수가 줄어듦
2. 중복 원소가 많을수록 효율적 (필요한 탐색만 진행)
3. 전체 시간복잡도: O(N!)보다 작음 (중복된 가지 치기)

### 배운 점
1번 코드 
- 결과를 string으로 저장하고 set에 넣어서 중복 결과가 안 나오게 했다.
- 근데 문제 의도가 이게 아닌 것 같아서 다시 품

2번 코드
- sort를 했기 때문에 같은 수들은 연속되어 나오게 된다.
- Pre 라는 변수를 통해 해당 깊이의 수를 저장한다.
- 이전 깊이의 수와 현재 수가 같으면 돌리지 않는다. - 왜? 중복된 결과를 낳을 것이기 때문!