### PR TITLE
Solved: [백트래킹] BOJ_N과 M (9) 김나영

### DIFF
--- a/백트래킹/나영/BOJ_15663_N과 M (9).java
+++ b/백트래킹/나영/BOJ_15663_N과 M (9).java
@@ -1,0 +1,53 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int n, m;
+    static int [] arr;
+    static boolean [] visited;
+    static List<Integer> list = new ArrayList<>();
+    static StringBuilder sb = new StringBuilder();
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        arr = new int[n];
+        visited = new boolean[n];
+        
+        st = new StringTokenizer(br.readLine());
+
+        for (int i = 0; i < n; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        Arrays.sort(arr);
+
+        dfs(0, new int[m]);
+        
+        System.out.println(sb.toString());
+    }
+
+    static void dfs(int cnt, int [] perm) {
+        if (cnt == m) {
+            for (int i : perm) {
+                sb.append(i).append(" ");
+            }
+            sb.append("\n");
+            return;
+        }
+
+        int prev = -1;
+        
+        for (int i = 0; i < n; i++) {
+            if(visited[i] || arr[i] == prev) continue;
+            prev = arr[i];
+            visited[i] = true;
+            perm[cnt] = arr[i];
+            dfs(cnt+1, perm);
+            visited[i] = false;
+        }
+    }
+}


### PR DESCRIPTION
### 자료구조
- 배열

### 알고리즘
- 백트래킹

### 시간복잡도
- 중복 없는 순열을 추출해야 함
- 최악의 시간복잡도 : nPm 

### 배운점
- 배열에 중복되는 숫자가 들어오지만, 순열은 중복되게 출력하면 안 된다(이런 제기랄)
- 처음에는 숫자 자체를 중복되게 출력하면 안 되는 줄 알았는데,,, ㄹㅇ 똑같이 생긴 순열을 없애야 하는 거였음
- 그래서 prev를 통해 이전 값을 계속 갖고 다니며 출력 시 이전 값과 같은 값이 있으면 continue로 dfs를 돌게 하지 않는다.