### PR TITLE
Solved: [백트래킹] BOJ_N과 M (11) 홍지우

### DIFF
--- a/백트래킹/지우/BOJ_15665_N과 M (11).cpp
+++ b/백트래킹/지우/BOJ_15665_N과 M (11).cpp
@@ -1,0 +1,43 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+
+int N, M;
+vector<int> nums;
+vector<int> picks;
+
+void dfs(int pIdx) {
+    if(pIdx == M) {
+        for(int i=0; i<M; i++) {
+            cout << picks[i] << " ";
+        }
+        cout << "\n";
+        return;
+    }
+
+    int pre = -1; // 같은 레벨에서 같은 숫자를 중복으로 사용하지 않도록 이전 값 저장!
+    
+    for(int i=0; i<N; i++) {
+        if(pre == nums[i]) continue;
+        picks.push_back(nums[i]);
+        dfs(pIdx+1);
+        picks.pop_back();
+        pre = nums[i]; // 현재 깊이의 수 끝! Pre로 전달
+    }
+        
+}
+
+int main() {
+    cin.tie(0); cout.tie(0); ios::sync_with_stdio(0);
+    cin >> N >> M;
+    nums.resize(N,0);
+    for(int i=0; i<N; i++) {
+        cin >> nums[i];
+    }
+    sort(nums.begin(), nums.end());
+    dfs(0);
+    
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터

### 알고리즘
- 중복을 제거한 순열(중복 허용 안함, 방문 체크 없음)

### 시간복잡도
1. 중복 숫자가 없으면 총 경우의 수는 O(N^M) (중복 가능하므로)
2. 하지만 `pre == nums[i]` 조건으로 **같은 깊이에서 같은 숫자 사용 방지 → 중복 제거**
3. 따라서 실제 시간복잡도는 **중복 제거된 N^M 이하**, 정확히는 **중복 없는 중복순열**

### 배운 점
- 각 자리에서 처음부터 ~ 끝까지 올 수 있는 상황
- 여기서도 중복된 결과는 나오면 안됨
- 같은 깊이의 숫자를 저장하여 같은 깊이, 같은 숫자에서 2번 타지 않도록 한다.