### PR TITLE
Solved: [백트래킹] BOJ_N과 M (11) 김나영

### DIFF
--- a/백트래킹/나영/BOJ_15665_N과 M (11).java
+++ b/백트래킹/나영/BOJ_15665_N과 M (11).java
@@ -1,0 +1,47 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int n, m;
+    static int [] arr;
+    static StringBuilder sb = new StringBuilder();
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        arr = new int[n];
+        
+        st = new StringTokenizer(br.readLine());
+
+        for (int i = 0; i < n; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        Arrays.sort(arr);
+
+        dfs(0, new int[m]);
+        
+        System.out.println(sb.toString());
+    }
+
+    static void dfs(int cnt, int [] perm) {
+        if (cnt == m) {
+            for (int i : perm) {
+                sb.append(i).append(" ");
+            }
+            sb.append("\n");
+            return;
+        }
+
+        int prev = -1;
+        for (int i = 0; i < n; i++) {
+            if (prev == arr[i]) continue;
+            prev = arr[i];
+            perm[cnt] = arr[i];
+            dfs(cnt+1, perm);
+        }
+    }
+}


### PR DESCRIPTION
### 자료구조
- 배열

### 알고리즘
- 백트래킹

### 시간복잡도
- 중복을 허용한 순열을 출력
- 최악의 경우 모든 수에 대해 중복 순열을 출력할 수 있음
- 최악의 경우 n ^ m = 8 ^ 8 = 16,777,216
- 최종 시간복잡도 : **O(n^m)**

### 배운점
- prev를 통해 이전 값을 저장하고, 다음 값으로 이동할 때 이전 값과 동일한지 확인하며 계산했다
- 이전 문제와 다른 점은 중복을 허용한 순열이므로 dfs 시 visited 배열을 빼 주었다