### PR TITLE
Solved: [백트래킹] BOJ_N과 M (12) 홍지우

### DIFF
--- a/백트래킹/지우/BOJ_15666_N과 M (12)_4.cpp
+++ b/백트래킹/지우/BOJ_15666_N과 M (12)_4.cpp
@@ -1,0 +1,43 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+
+int N, M;
+vector<int> nums;
+vector<int> picks;
+
+void dfs(int s, int pIdx) {
+    if(pIdx == M) {
+        for(int i=0; i<M; i++) {
+            cout << picks[i] <<" ";
+        }
+        cout << "\n";
+        return;
+    } 
+
+    int pre = -1;
+    
+    for(int i=s; i<N; i++) {
+        if(pre == nums[i]) continue;
+        picks.push_back(nums[i]);
+        dfs(i, pIdx+1);
+        picks.pop_back();
+        pre = nums[i];
+    }
+        
+}
+
+int main() {
+    cin.tie(0); cout.tie(0); ios::sync_with_stdio(0);
+    cin >> N >> M;
+    nums.resize(N,0);
+    for(int i=0; i<N; i++) {
+        cin >> nums[i];
+    }
+    sort(nums.begin(), nums.end());
+    dfs(0, 0);
+    
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터

### 알고리즘
- 중복조합

### 시간복잡도
1. 중복 조합이므로 최대 경우의 수는 O((N+M-1)Cm) → 최악은 O(N^M)
2. 같은 깊이에서 같은 숫자는 제외(pre 활용) → 중복 결과 제거
3. 시간복잡도는 O(N^M)이지만 중복 제거로 실질 수행량은 줄어듦

### 배운 점
- 중복조합. 즉, 이전에 나온 숫자 포함하여 끝까지 다시 등장할 수 있는 조합
- dfs 뒤로 넘길 때 현재의 인덱스를 뒤로 준다. 그럼 현재 인덱스부터 ~N까지 다음 깊이에서 깊어진다. 
1 1
1 7
1 9
7 7
7 9
9 9