### PR TITLE
Solved: [백트래킹] BOJ_연산자 끼워넣기 홍지우

### DIFF
--- a/그래프 탐색/지우/BOJ_14888_연산자 끼워넣기.cpp
+++ b/그래프 탐색/지우/BOJ_14888_연산자 끼워넣기.cpp
@@ -1,0 +1,63 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+#include <climits>
+
+using namespace std;
+
+int N;
+int min_ans = INT_MAX; 
+int max_ans = INT_MIN;
+vector<int> nums;
+vector<int> cntOp;
+int operators[] = {1,-1};
+
+int NextSum(int sum, int d, int i) {
+    if(d<2) {
+        int nxt = nums[i] * operators[d];
+        return sum + nxt;
+    }
+    else if(d==2) {
+        return sum * nums[i];
+    }
+    else {
+        if(sum < 0) return abs(sum) / nums[i] * -1;
+        return sum/nums[i];
+    }
+}
+
+void dfs(int sum, int s) {
+    if(s == N) {
+        min_ans = min(min_ans, sum);
+        max_ans = max(max_ans, sum);
+    }
+
+    for(int d=0; d<4; d++) {
+        if(cntOp[d] > 0) {
+            cntOp[d]--;
+            int nxtSum = NextSum(sum, d, s);
+            dfs(nxtSum, s+1);
+            cntOp[d]++;
+        }
+    }
+
+}
+
+int main() {
+    cin.tie(0); cout.tie(0);
+    ios::sync_with_stdio(0);
+    cin >> N;
+    nums.resize(N,0);
+    cntOp.resize(4,0);
+    for(int i=0; i<N; i++) {
+        cin >> nums[i];
+    }
+
+    for(int i=0; i<4; i++) {
+        cin >> cntOp[i];
+    }
+
+    dfs(nums[0],1);
+    cout << max_ans << "\n" << min_ans;    
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터

### 알고리즘
- 백트래킹

### 시간복잡도
1. 연산자 개수의 총합은 N-1개이므로, 최대 O((N-1)!)개의 순열 탐색
2. 각 연산자 자리에 4가지 연산 가능 → 최악의 경우 O(4^(N-1)) 정도

### 배운 점
- nums는 처음부터 끝까지 한 번씩 꼭 나와야 한다.
    - idx로 관리해서 처음부터 끝까지 도달하게끔. idx == N이면 끝! 이렇게 설계
- 여기서 dfs를 타야 하는 건 '연산자'이다. 따라서 nums[0]은 이미 반영된 상태로 dfs(Nums[0], 1) 이렇게 시작
- 중간중간 연산자 0~4 까지 쓸 수 있는 연산자 있으면 
    - cntOp에서 하나 빼서 넣고 -> dfs로 Sum 반영해서 뒤로 타기 -> 같이 깊이에서 연산자 다른걸 사용할 수 있게 cntOp 복귀
