### PR TITLE
Solved: [백트래킹] BOJ_연산자 끼워넣기 김나영

### DIFF
--- a/백트래킹/나영/BOJ_14888_연산자 끼워넣기.java
+++ b/백트래킹/나영/BOJ_14888_연산자 끼워넣기.java
@@ -1,0 +1,60 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int n, max=Integer.MIN_VALUE, min=Integer.MAX_VALUE;
+    static int [] arr1, arr2;
+    public static void main(String[] args) throws IOException {
+        n = Integer.parseInt(br.readLine());
+        
+        arr1 = new int[n];
+        arr2 = new int[4];
+        
+        st = new StringTokenizer(br.readLine());
+
+        for (int i = 0; i < n; i++) {
+            arr1[i] = Integer.parseInt(st.nextToken());
+        }
+        
+        st = new StringTokenizer(br.readLine());
+
+        for (int i = 0; i < 4; i++) {
+            arr2[i] = Integer.parseInt(st.nextToken());
+        }
+
+        dfs(0, new int[n-1]);
+        
+        System.out.println(max + "\n" + min);
+    }
+
+    static void dfs(int cnt, int [] perm) {
+        if (cnt == n-1) {
+            int sum = arr1[0];
+            for (int i = 1; i < n; i++) {
+                sum = cal(sum, arr1[i], perm[i-1]);
+            }
+            max = Math.max(max, sum);
+            min = Math.min(min, sum);
+            return;
+        }
+
+        for (int i = 0; i < 4; i++) {
+            if (arr2[i] == 0) continue;
+            arr2[i] = arr2[i] - 1;
+            perm[cnt] = i;
+            dfs(cnt + 1, perm);
+            arr2[i] = arr2[i] + 1;
+        }
+    }
+
+    static int cal(int sum, int a, int b) {
+        if (b == 0) sum += a;
+        else if (b == 1) sum -= a;
+        else if (b == 2) sum *= a;
+        else sum /= a;
+        return sum;
+    }
+}


### PR DESCRIPTION
### 자료구조
- 배열

### 알고리즘
- 백트래킹
- 순열

### 시간복잡도
- 연산자 개수에 제한이 없다면 O(4^n-1)
- 하지만 연산자의 개수가 지정되어 있으므로 최종 시간복잡도는 
<img width="401" height="111" alt="image" src="https://github.com/user-attachments/assets/c3cb68b2-b28c-44a8-b72f-3d7214f0e257" />

### 배운점
- 중복순열을 이용해서 연산자를 추출하는 문제
- 숫자는 순서를 무조건 지켜야 하므로 그대로 두고, 부호에 대해서만 dfs 돌려 갯수가 0이 아니라면 추출시켰다
- 다시 생각해보니 pre를 이용해 동일한 부호에 대한 중복값을 제거했다면 더 최적화되었을 것 같다 헤헷