### PR TITLE
Solved: [백트래킹] BOJ_줄어드는 수 김나영

### DIFF
--- a/백트래킹/나영/BOJ_1174_줄어드는 수.java
+++ b/백트래킹/나영/BOJ_1174_줄어드는 수.java
@@ -1,0 +1,29 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static int n;
+    static int [] arr = {9,8,7,6,5,4,3,2,1,0};
+    static List<Long> list = new ArrayList<>();
+    static StringBuilder sb = new StringBuilder();
+    public static void main(String[] args) throws IOException {
+        n = Integer.parseInt(br.readLine());
+
+        dfs(0, 0);
+
+        list.sort(null);
+
+        if(n <= list.size()) System.out.println(list.get(n-1));
+        else System.out.println(-1);
+    }
+
+    static void dfs(int start, long sum) {
+        if(start!=0) list.add(sum);
+        
+        for (int i = start; i < 10; i++) {
+            dfs(i+1, sum*10+arr[i]);
+        }
+    }
+}


### PR DESCRIPTION
### 자료구조
- 배열
- ArrayList

### 알고리즘
- 백트래킹
- 조합

### 시간복잡도
- 공집합을 제외한 모든 부분집합의 개수를 구하는 문제 => 조합으로 생각하고 풀어야 한다
- 숫자 10개에서 부분집합을 선택하는 갯수 : O(2^10)
- list 정렬 시간복잡도 : O(m log m) => O(1023 log 1023)
- 최종 시간복잡도
<img width="697" height="60" alt="image" src="https://github.com/user-attachments/assets/38ab0aae-74a2-44ae-8bc7-b7ef6f00ef7a" />

### 배운점
- 처음엔 visited를 통해 방문처리 하면서 풀려고 했지만,,,, 시초날거같음 + 로직 정리가 너무 어려워짐으로 인해 급선회
- 지우의 꿀팁으로 9~0까지의 배열을 만들고 해당 배열에 대한 모든 부분집합(공집합 제외)을 구해 list에 저장한 뒤, sorting 해 주었다
- 여기서 공집합 제거 안 해줘서 한 번 틀림ㅎㅎ 꼬옥 해주기~^^