### PR TITLE
Solved: [백트래킹] BOJ_선발 명단 김나영

### DIFF
--- a/백트래킹/나영/BOJ_3980_선발 명단.java
+++ b/백트래킹/나영/BOJ_3980_선발 명단.java
@@ -1,0 +1,42 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int C, max;
+    static int [][] player;
+    static boolean [] visited;
+    public static void main(String[] args) throws IOException {
+        C = Integer.parseInt(br.readLine());
+        for (int t = 0; t < C; t++) {
+            player = new int [11][11];
+            visited = new boolean [11];
+            max = 0;
+            for (int r = 0; r < 11; r++) {
+                st = new StringTokenizer(br.readLine());
+                for (int c = 0; c < 11; c++) {
+                    player[r][c] = Integer.parseInt(st.nextToken());
+                }
+            }
+            
+            System.out.println(dfs(0, 0));
+        }
+    }
+
+    static int dfs(int r, int sum) {
+        if (r == 11) {
+            return sum;
+        }
+
+        for (int i = 0; i < 11; i++) {
+            if(visited[i] || player[r][i] == 0) continue;
+            visited[i] = true;
+            max = Math.max(dfs(r + 1, sum + player[r][i]), max);
+            visited[i] = false;
+        }
+
+        return max;
+    }
+}


### PR DESCRIPTION
### 자료구조
- 배열

### 알고리즘
- 백트래킹
- 순열

### 시간복잡도
- 모든 선수들의 모든 포지션에 대한 sum 값을 계산해 출력 => 순열 추출
- 만약 해당 포지션에서 player의 능력치가 0이라면 배치할 수 없으므로 continue
- 최악의 경우 모든 순열의 합을 구해야 하므로 시간복잡도는 nPm

<img width="471" height="125" alt="image" src="https://github.com/user-attachments/assets/df9e0a37-0678-4191-92b6-eb5363bcf85b" />

- 최악의 시간복잡도는 **O(11!)**
- 1초까지는 아슬아슬하게 세이프

### 배운점
-  visited 배열을 이용한 순열 문제이지만, 해당 player가 특정 포지션에서 능력치가 0이라면 쓸 수 없다는 점을 명심해야 했다
- 그래서 값을 체크하면서 dfs를 돌렸고, r이 11까지 왔을 때 sum을 return 시켜 ans와 max값을 비교했습니다라랏