### PR TITLE
Solved: [백트래킹] BOJ_선발 명단 홍지우

### DIFF
--- a/백트래킹/지우/BOJ_3980_선발 명단.cpp
+++ b/백트래킹/지우/BOJ_3980_선발 명단.cpp
@@ -1,0 +1,43 @@
+#include <iostream>
+#include <vector>
+#include <cmath>
+
+using namespace std;
+
+vector<vector<int>> powers;
+vector<bool> vis;
+int maxAns;
+
+void dfs(int sIdx, int sum) {
+    if(sIdx == 11) {
+        maxAns = max(maxAns, sum);
+        return;
+    }
+
+    for(int i=0; i<11; i++) {
+        if(!vis[i] && powers[i][sIdx] > 0) {
+            vis[i] = true;
+            dfs(sIdx+1, sum + powers[i][sIdx]);
+            vis[i] = false;
+        }
+    }
+}
+
+int main() {
+    int T; cin >> T;
+    while(T--) {
+        powers.assign(11,vector<int>(11,0));
+        vis.assign(11,false);
+        maxAns = -1;
+
+        for(int r=0; r<11; r++) {
+            for(int c=0; c<11; c++) {
+                cin >> powers[r][c];
+            }
+        }
+
+        dfs(0,0);
+        cout << maxAns << "\n";
+    }
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터

### 알고리즘
- 백트래킹

### 시간복잡도
1. 선수 11명을 포지션 11곳에 배치하는 모든 경우 탐색 → 최대 11! 경우의 수.
2. 각 포지션마다 11명의 후보 중 하나를 선택, 백트래킹으로 방문 여부 체크 → O(11!).
3. T개의 테스트 케이스 처리 시 → O(T × 11!) = O(T × 39,916,800).

### 배운 점
- 총 11개의 숫자로 이루어진, 순서가 중요한 수열을 만든다고 생각하면 됨
- vis 처리하지 않고, 해당 포지션(sIdx)의 능력이 0 이상이면 다음 dfs의 주인공!이 될 수 있게 했다.