### PR TITLE
Solved: [백트래킹] BOJ_계란으로 계란치기 김나영

### DIFF
--- a/백트래킹/나영/BOJ_16987_계란으로 계란치기.java
+++ b/백트래킹/나영/BOJ_16987_계란으로 계란치기.java
@@ -1,0 +1,57 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int n, ans;
+    static int [] d, w;
+    // static boolean [] visited;
+    public static void main(String[] args) throws IOException {
+        n = Integer.parseInt(br.readLine());
+        d = new int [n];
+        w = new int [n];
+        // visited = new boolean [n];
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            // a가 내구도, b가 무게
+            d[i] = a;
+            w[i] = b;
+        }
+        
+        System.out.println(dfs(0, d));
+    }
+
+    static int dfs(int cnt, int [] eggs) {
+        if (cnt == n) {
+            int sum = 0;
+            for (int e : eggs) {
+                if (e <= 0) sum++;
+            }
+            return sum;
+        }
+
+        if (eggs[cnt] <= 0) return dfs(cnt + 1, eggs);
+
+        boolean isS = false;
+        
+        for (int i = 0; i < n; i++) {
+            if(eggs[i] <= 0 || cnt == i) continue;
+            isS = true;
+            int [] ex = eggs.clone();
+
+            ex[cnt] -= w[i];
+            ex[i] -= w[cnt];
+            
+            ans = Math.max(dfs(cnt + 1, ex), ans);
+        }
+
+        if (!isS) ans = Math.max(dfs(cnt + 1, eggs), ans);
+
+        return ans;
+    }
+}


### PR DESCRIPTION
### 자료구조
- 배열

### 알고리즘
- 백트래킹

### 시간복잡도
- 총 n개의 계란 중 칠 수 있는 계란은 n-1개, n-2개,,,
- 즉 (n-1) * (n-2) * ,,, * 1 = **(n-1)!**
- 최종 시간복잡도 : **O(n!)**

### 배운점
- 이해가 어려웠던 문제,,, 가독성 실화입니까~
- 결론적으로 0번 계란이 1~n번까지 **한 번** 치고, 1번 계란에게 dfs로 순번을 넘긴다.
- 넘긴 순번이 n과 같아질 경우 해당 계란 내구도 배열에서 0보다 작은 경우 sum++로 깨진 계란의 수를 센다.
- 해당 로직에서 신경써야 했던 부분은 
    1. 현재 순번의 계란이 깨졌다면 바로 순번 넘기기
    2. 원래 내구도와 무게를 2차원 배열에 담으려고 했는데, 그럼 clone을 쓸 수가 없어 그냥 1차원 배열로 바꿔 풀었습니다
    3. 복사한 배열에 현재 순번의 달걀과 for문 내의 선택된 달걀의 부딪힌 내구도를 반영
    4. dfs로 다음 순번, 내구도를 반영한 배열을 넘겨 줌
    5. 만약 해당 순번에서 깨트릴 계란이 없어도, cnt를 n까지 더해 해당 경우의 깨진 계란의 수를 세야 하므로 isS를 통해 이미 모든 계란이 깨져서 for문이 돌지 않아도 cnt+1로 끝까지 탐색할 수 있도록 했습니다라라