### PR TITLE
Solved: [백트래킹] BOJ_넴모넴모 (Easy) 홍지우

### DIFF
--- a/백트래킹/지우/BOJ_14712_넴모넴모 (Easy).cpp
+++ b/백트래킹/지우/BOJ_14712_넴모넴모 (Easy).cpp
@@ -1,0 +1,38 @@
+#include <iostream>
+#include <vector>
+
+using namespace std;
+
+int N, M;
+int ans;
+vector<vector<bool>> maps;
+
+void dfs(int idx) {
+    if(idx == N*M) { // 끝까지 다 돌았다! (네모 없는 애들만 모았음.!)
+        ans++;
+        return;
+    }
+
+    int r = idx/M + 1; 
+    int c = idx%M + 1;
+
+    if(maps[r-1][c] && maps[r][c-1] && maps[r-1][c-1]) { // 위쪽 방향으로 2*2 모두 채워졌다?
+        dfs(idx+1); //절대 maps[r][c] 에 채우면 안돼! (이럼 만들어지니까)
+    }
+    else {
+        maps[r][c] = true;
+        dfs(idx+1);
+        maps[r][c] = false;
+        dfs(idx+1);
+    }
+}
+
+int main() {
+    cin >> N >> M;
+    maps.resize(N+1, vector<bool>(M+1, false));
+
+    dfs(0);
+    cout << ans;
+                                              
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터

### 알고리즘
- 백트래킹

### 시간복잡도
1. **최악의 경우**: 모든 칸마다 놓을지/안놓을지 두 가지 경우를 재귀로 탐색 → \(O(2^{N x M})\)  
2. **가지치기 효과**: `if(maps[r-1][c] && maps[r][c-1] && maps[r-1][c-1])` 조건으로 일부 탐색이 줄어듦 → 실제는 더 작음  
3. **공간복잡도**: `maps`는 \(O(N \times M)\) 크기의 2D 배열, 재귀 호출 스택은 최대 \(O(N \times M)\)  

### 배운 점
아이디어 생각하는데 힘들었던 문제
[1차 아이디어]
- 모든 경우의 수 2^{N x M} - 2*2가 가능한 경우의 수 : 이렇게 하려고 했다
- 그러나 2*2를 만족한 네모 외에 다른 빈 칸들도 조합으로 처리를 해줘야 하고, 중복도 빼야 하고.. 뭔가 이 길이 아닌 것 같았다.

[SOLVED]
- (N+1)*(M+1) 판을 만들어두고 2x2를 만족하지 않게끔 dfs를 돌렸다.
- 정방향 순회하며 
    - (위, 대각선 위, 왼쪽)이 모두 true이면 절대 현재 위치는 방문하지 않게끔 한다. // 2x2 만들어지기 직전이니까!!!
        - 그냥 idx+1 해서 다음으로 넘기기
    -  그게 아니면 방문한다! 다음! dfs(+1) / 방문 안 한다! 다음! dfs(+1)
- 예전에 썼던 int r = idx / 열 , int c = idx / 행; 아이디어 사용했다.