### PR TITLE
Solved: [백트래킹] BOJ_N-Queen 홍지우

### DIFF
--- a/백트래킹/지우/BOJ_9663_NQueen.cpp
+++ b/백트래킹/지우/BOJ_9663_NQueen.cpp
@@ -1,0 +1,67 @@
+#include <iostream>
+#include <vector>
+
+using namespace std;
+
+int N; int ans = 0;
+vector<vector<bool>> maps;
+vector<bool> visCol;
+vector<bool> visRow;
+
+int dr[] = {-1,-1};
+int dc[] = {-1,1};
+
+bool inRange(int r, int c) {
+    return r>=0 && r<N && c>=0 && c<N;
+}
+
+bool checkDiag(int r, int c) {
+    for(int d=0; d<2; d++) { // dfs이니까 위에만 보면 된다.
+        int nr = r;
+        int nc = c;
+        while(1) {
+            nr += dr[d];
+            nc += dc[d];
+            if(inRange(nr,nc)) {
+                if(maps[nr][nc]) return false;
+            } else {
+                break;
+            }
+        }
+    }
+
+    return true;
+}
+
+void dfs(int r) { // 한 행에 한 퀸을 놓아야 N개를 놓을 수 있다.
+    if(r == N) {
+        ans++;
+        return;
+    }
+
+    for(int c=0; c<N; c++) {
+        if(!visCol[c] && checkDiag(r,c)) {
+            visCol[c] = true;
+            maps[r][c] = true;
+            
+            dfs(r+1);
+    
+            visCol[c] = false;
+            maps[r][c] = false;
+        }
+    }
+
+    
+}
+
+int main() {
+    cin.tie(0); cout.tie(0); ios::sync_with_stdio(0);
+    cin >> N;
+    maps.resize(N, vector<bool>(N,false));
+    visCol.resize(N,false);
+    visRow.resize(N,false);
+
+    dfs(0);
+    cout << ans;
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터

### 알고리즘
- 백트래킹

### 시간복잡도
1. **DFS 재귀 깊이** → 각 행에 퀸 1개를 배치하므로 깊이는 \( N \)  
2. **각 행의 탐색 범위** → 최대 \( N \)개의 열 후보 × 대각선 검사 `O(N)` → 한 행당 \( O(N^2) \)  
3. **총 시간복잡도** → \( O(N \cdot N!) \)
<img width="173" height="41" alt="스크린샷 2025-08-12 오전 9 53 05" src="https://github.com/user-attachments/assets/e05a3b63-120a-4fe0-9928-e1004efb67d7" />

### 배운 점
- N개의 퀸 각 행에 하나씩 있어야 N개가 만들어질 수 있다.
    - 따라서 처음에 idx로 모든 칸을 검사하려 했지만, 행 관점에서 하나씩만 놓고 지나가는 설계로 바꿨다.
- 대각선 처리
    - 이미 지나온 곳에 queen 이 있는지 확인하기 위해 왼쪽위, 오른쪽위 대각선 체크 로직을 두었다.
    - 다른 사람들 코드를 보니까 vis[r-c +(N-1)] (여기서 N-1은 값 보정용) 배열을 두어 O(1)로 체크하게끔 두었다. <- 이럼 시간복잡도를 1/N 줄일 수 있다!
