### PR TITLE
Solved: [백트래킹] BOJ_죽음의 비 홍지우

### DIFF
--- a/백트래킹/지우/BOJ_22944_죽음의 비.cpp
+++ b/백트래킹/지우/BOJ_22944_죽음의 비.cpp
@@ -1,0 +1,89 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+
+using namespace std;
+
+int N, H, D;
+vector<vector<char>> maps;
+vector<vector<int>> dp;
+queue<vector<int>> q;
+int ans = -1;
+
+int dr[] = {-1, 0, 1, 0};
+int dc[] = {0, -1, 0, 1};
+
+bool inRange(int r, int c) {
+    return r>=0 && r<N && c>=0 && c<N;
+}
+
+void bfs() {
+    while(!q.empty()) {
+        
+        vector<int> curr = q.front(); q.pop();
+        int r = curr[0]; 
+        int c = curr[1]; 
+        int umb = curr[2]; // 우산 내구도
+        int power = curr[3]; 
+        int move = curr[4];
+        
+        for(int d=0; d<4; d++) {
+            int nr = r + dr[d];
+            int nc = c + dc[d];
+            if(!inRange(nr, nc)) continue;
+
+            int nUmb = umb;
+            int nPower = power;
+
+            if(maps[nr][nc] == 'E') {
+                ans = move + 1;
+                return;
+            }
+
+            if(maps[nr][nc] == 'U') {
+                nUmb = D-1; // 우산 새로 주워도 비 때문에 깎임 (예제3. 체력 1이 남는다고 써있음)
+            }
+            
+            if(maps[nr][nc] == '.') {
+                if(umb > 0) {
+                    nUmb--;
+                } else {
+                    nPower--;
+                }
+            }
+
+            if(nPower <= 0) continue;
+            int total = nPower + nUmb;
+            if(dp[nr][nc] < total) {
+                dp[nr][nc] = total;
+                q.push({nr, nc, nUmb, nPower, move+1});
+            }
+            
+        }
+    }
+
+    return;
+}
+
+
+int main() {
+    cin.tie(0); cout.tie(0); ios::sync_with_stdio(0);
+    cin >> N >> H >> D;
+    maps.resize(N,vector<char>(N,'\0'));
+    dp.resize(N,vector<int>(N,-1));
+
+    for(int r=0; r<N; r++) {
+        for(int c=0; c<N; c++) {
+            cin >> maps[r][c];
+            if(maps[r][c] == 'S') {
+                dp[r][c] = H;
+                q.push({r,c, 0, H, 0});
+            }
+        }
+    }
+
+      
+    bfs();
+    cout << ans;
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터, 큐

### 알고리즘
- 백트래킹
- 그래프탐색

### 시간복잡도
1. **최대 정점 수**: `dp`가 2차원 배열이므로, 방문 상태 개수는 최대 `N^2`.
2. **간선 수**: 각 정점에서 최대 4방향으로 이동하므로, 간선 수는 `O(4 * N^2) = O(N^2)`.
3. **총 시간복잡도**: BFS이므로 `O(N^2)`.

**제한 조건 대입 시**  
`N = 500` → 최대 연산 횟수 ≈ 250,000 (충분히 1초 이내 수행 가능)

### 배운 점
- 어렵다 .
- 이 문제도 다음으로 넘어갈 때의 조건이 다른 문제이다. 즉, vis 배열을 잘 처리해야 하는 문제 (어떻게 갈 곳, 안 갈 곳을 구별할지가 관건)
- 그러나 map 자체가 바뀌진 않는다. 체력에 따라 갈 수 있는 곳이 달라질 뿐.
 ➡️ dp[r][c] = 총 체력의 **최댓값**!
    - 총 체력 = power(사람 체력) + umb(우산 내구도)
    - dp는 갈 수 있는 최대 체력만 갈 수 있다. if(dp[nr][nc] < total) 만 q에 넣어주기
    - (**`vis 역할`**) 다녀온 곳은 무조건 현재 체력보다 크니까 다시 돌아가지 않게 된다.
    - (**`문제 특수성 반영 vis _ 간 곳도 다시 갈 수 있음`**) 다른 우산 내구도 덕분에 체력이 더 커진 친구도 앞 친구가 다녀간 곳을 방문할 수 있게 된다. 왜? 체력 깡패니까.
- U, . 일 때의 총 체력을 모아 마지막에 판별해서 넣어줄지 말지~ 결정하게끔 코드를 짰다


- [문제 잘 읽자.] U 인 곳을 방문했을 때, 새로 쓴 우산에도 내구도-1 이 진행된다. 
    - 예제 3을 보면 E 도착 시 체력 1이 남았다고 했다.
<img width="227" height="76" alt="스크린샷 2025-08-13 오전 11 05 09" src="https://github.com/user-attachments/assets/45799385-c0ff-4041-b26b-5b49711f1134" />
<img width="124" height="99" alt="스크린샷 2025-08-13 오전 11 05 35" src="https://github.com/user-attachments/assets/87409dbb-edd8-4328-933f-22e993ab94e6" />
