### PR TITLE
Solved: [백트래킹] BOJ_색종이 붙이기 홍지우

### DIFF
--- a/백트래킹/지우/BOJ_17136_색종이 붙이기.cpp
+++ b/백트래킹/지우/BOJ_17136_색종이 붙이기.cpp
@@ -1,0 +1,75 @@
+#include <iostream>
+#include <vector>
+
+using namespace std;
+
+int ans = 100;
+vector<vector<int>> maps;
+int paper[] = {0, 5, 5, 5, 5, 5};
+
+bool inRange(int r, int c) {
+    return r>=0 && r<10 && c>=0 && c<10;
+}
+
+void check(int sr, int sc, int i, int b) {
+    for(int r=sr; r<sr+i; r++) {
+        for(int c=sc; c<sc+i; c++) {
+            maps[r][c] = b;
+        }
+    }
+    return;
+}
+
+bool canGlue(int sr, int sc, int i) {
+    for(int r=sr; r<sr+i; r++) {
+        for(int c=sc; c<sc+i; c++) {
+            if(!inRange(r,c) || maps[r][c] == 0) return false;
+        }
+    }
+    return true;
+}
+
+void dfs(int idx, int cnt, int cntOne) {
+    if(cntOne == 0) {
+        ans = min(ans, cnt);
+        return;
+    }
+    if(idx == 100) return;
+    
+    int r = idx/10;
+    int c = idx%10;
+
+    if(maps[r][c] != 1) dfs(idx+1, cnt, cntOne);
+
+    for(int i=1; i<=5; i++) {
+        if(paper[i] > 0 && canGlue(r,c,i)) {
+            check(r,c,i, 0);
+            paper[i]--;
+            
+            dfs(idx+1, cnt+1, cntOne - i*i);
+            check(r,c,i, 1);
+            paper[i]++;
+        }
+    }
+}
+
+int main() {
+    cin.tie(0); cout.tie(0); ios::sync_with_stdio(0);
+    maps.resize(10, vector<int>(10,0));
+    int cnt1 = 0;
+
+    for(int r=0; r<10; r++) {
+        for(int c=0; c<10; c++) {
+            cin >> maps[r][c];
+            if(maps[r][c] == 1) {
+                cnt1++;
+            }
+        }
+    }
+
+    dfs(0,0, cnt1);
+    if(ans == 100) ans = -1;
+    cout << ans;
+
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터

### 알고리즘
- 백트래킹

### 시간복잡도
- 최대 100칸(10×10)에서 각 칸에 대해 최대 5가지 색종이 크기를 시도하므로 **O(5^(100))**이 이론적 최악.
- 단, canGlue 검사는 O(k²) (k ≤ 5)로 상수 취급 가능하고, 백트래킹으로 많은 경우 가지치기.
- 실제 시간은 1의 개수(cntOne)와 색종이 개수 제한에 따라 크게 줄어 평균은 O(백트래킹 가지 수 × 25) 수준.

### 배운 점
- dfs( map상 위치, 종이 개수, 남은 1의 개수) 돌려돌려!
- 1~5 까지의 크기를 돌려서 해당 크기의 종이가 남아있고, 해당 범위만큼 1이 존재한다면(canGlue)
    - 해당 범위 0으로 바꿔주기+해당 종이수-- / dfs(다음) / 원상복구
- 남은 1의 개수가 0이 되면 ans가 들어오는 수 중 가장 작게끔 처리하고
- 남은 1의 개수가 아직 0이 되지 않았는데 maps 끝까지 전부 돌았드면 그냥 return~