### PR TITLE
Solved: [백트래킹] BOJ_색종이 붙이기 김나영

### DIFF
--- a/백트래킹/나영/BOJ_17136_색종이 붙이기.java
+++ b/백트래킹/나영/BOJ_17136_색종이 붙이기.java
@@ -1,0 +1,81 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int [] arr = {5, 5, 5, 5, 5};
+    static int [][] map = new int[10][10];
+    static boolean [][] visited = new boolean [10][10];;
+    static int ans = Integer.MAX_VALUE;
+    static List<int[]> list = new ArrayList<>();
+    public static void main(String[] args) throws IOException {
+        for (int r = 0; r < 10; r++) {
+            st = new StringTokenizer(br.readLine());
+            for (int c = 0; c < 10; c++) {
+                map[r][c] = Integer.parseInt(st.nextToken());
+                if (map[r][c] == 1) list.add(new int [] {r, c});
+            }
+        }
+
+        dfs(0, 0, arr);
+
+        System.out.println(ans == Integer.MAX_VALUE?-1:ans);
+        
+    }
+
+    static void dfs(int idx, int cnt, int [] ones) {
+        if (cnt >= ans) return;
+        if (idx == list.size()) {
+            ans = Math.min(ans, cnt);
+            return;
+        }
+
+        int r = list.get(idx)[0];
+        int c = list.get(idx)[1];
+        if (visited[r][c]) {
+            dfs(idx + 1, cnt, ones);
+            return;
+        }
+
+        for (int i = 0; i < 5; i++) {
+            if (ones[i] == 0) continue;
+            Set<int[]> set = fill(r, c, i+1);
+
+            if (set != null) {
+                for (int [] arr : set) {
+                    visited[arr[0]][arr[1]] = true;
+                }
+                
+                ones[i]--;
+                dfs(idx + 1, cnt + 1, ones);
+                ones[i]++;
+                
+                for (int [] arr : set) {
+                    visited[arr[0]][arr[1]] = false;
+                }
+            }
+        }
+    }
+
+    static Set<int []> fill(int r, int c, int num) {
+        Set<int[]> set = new HashSet<>();
+        for (int i = r; i < num + r; i++) {
+            for (int j = c; j < num + c; j++) {
+                if (!check(i, j) || map[i][j] == 0) return null;
+                set.add(new int[] {i, j});
+            }
+        }
+
+        if (set.size() == num * num) {
+            return set;
+        }
+
+        return null;
+    }
+
+    static boolean check(int r, int c) {
+        return r >= 0 && r < 10 && c >= 0 && c < 10 && !visited[r][c];
+    }
+}


### PR DESCRIPTION
### 자료구조
- ArrayList
- Set
- 배열

### 알고리즘
- 백트래킹
- 브루트포스

### 시간복잡도
- 최악의 경우 모든 칸을 돌면서 1 ~ 5 까지의 색종이를 붙이는 선택을 한다 : O(5^100)
- fill 메서드 : 5 * 5 = 최대 25까지 돌면서 체크
- 하지만 visited를 통해 각 칸에 있는 색종이를 확인하고, 또 색종이 면적에 따라 붙일 수 없는 경우의 수는 가지치기가 된다.
- 그리고 cnt가 ans보다 크면  return 시켜 최소값만 탐색하게 한다.
- 최악의 시간복잡도 : **O(5^25 * 25)** (하지만 가지치기로 여기까진 가지 않는다)

### 배운점
- 1이 위치한 좌표값을 list에 add
- 조회할 list의 인덱스, 사용한 색종이 개수, 색종이의 남은 개수 배열(ones)을 dfs에 넘긴다
- 그리고 for문으로 ones를 하나씩 돌며 해당 위치에 남은 색종이 개수가 0이 아니라면 fill(r, c, 해당 색종이 지름)를 넘겨준다
    - fill 에서는 해당 r, c에서 색종이 크기만큼 돌며 색종이 범위 내의 값이 방문 처리 되어있지 않고, 1이라면 set에 담아준다
    - 그리고 해당 set의 크기가 색종이 크기(지름 * 지름)와 같다면 set을 return, 그 외에는 모두 null을 return 한다
- fill의 return 값이 null이 아니라면 set에 좌표값들을 하나씩 빼면서 해당 위치들을 방문 처리한다
- 특정 색종이를 사용했으므로 그 부분도 ones[i]-- 해 준다
- 그리고 dfs(다음 리스트 인덱스, cnt + 1, ones) 넘김
- dfs 이후에 원상복구 가보자고

- 늘 하는 실수,,, visited 했으면 그냥 return 시키는 게 아니라 계속 dfs(idx + 1) 돌려서 끝까지 가 줘야 함 이 바보자식
- cnt >= ans는 시간복잡도를 줄이는 데에 대한 고민을 하다 추가한 부분 깔깔