### PR TITLE
Solved: [백트래킹] BOJ_비숍 홍지우

### DIFF
--- a/백트래킹/지우/BOJ_1799_비숍.cpp
+++ b/백트래킹/지우/BOJ_1799_비숍.cpp
@@ -1,0 +1,57 @@
+#include <iostream>
+#include <vector>
+
+using namespace std;
+
+int N; int ans = 0;
+vector<vector<int>> maps;
+vector<bool> vis1; // \ 방향 대각선
+vector<bool> vis2; // / 방향 대각선
+
+int dfs(int s, int cnt, vector<pair<int,int>>& ones) {
+    if(s == ones.size()) { 
+        return cnt;
+    }
+
+    int maxCnt = cnt;
+    
+    for(int i=s; i<ones.size(); i++) {
+        auto[r, c] = ones[i];
+        if(!vis1[r-c+N-1] && !vis2[r+c]) {
+            vis1[r-c+N-1] = vis2[r+c] = true;
+            maxCnt = max(maxCnt, dfs(i+1, cnt+1, ones));
+            vis1[r-c+N-1] = vis2[r+c] = false;
+        }
+    }
+
+    return maxCnt;
+}
+
+int main() {
+    cin.tie(0); cout.tie(0); ios::sync_with_stdio(0);
+    cin >> N;
+    maps.resize(N, vector<int>(N,0));
+    vector<pair<int,int>> whites(0);
+    vector<pair<int,int>> blacks(0);
+
+    for(int r=0; r<N; r++) {
+        for(int c=0; c<N; c++) {
+            cin >> maps[r][c];
+            if(maps[r][c] == 1) {
+                if((r+c)%2 == 0) {
+                    whites.push_back({r,c});
+                } else {
+                    blacks.push_back({r,c});
+                }
+            }
+        }
+    }
+    vis1.resize(2*N-1, false);
+    vis2.resize(2*N-1, false);
+
+    ans += dfs(0, 0, whites);
+    ans += dfs(0, 0, blacks);
+    cout << ans;
+    
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터

### 알고리즘
- 백트래킹

### 시간복잡도
1. 흰 칸과 검은 칸을 분리해 각각 DFS 탐색 → 각 경우의 좌표 수를 M_white, M_black이라 하면 탐색 복잡도는 O(2^(M_white) + 2^(M_black)).
2. 각 DFS에서 대각선 방문 여부를 확인하는 데 O(1), 깊이 M에 대해 백트래킹을 수행하므로 최악은 O(2^M).
3. N ≤ 10에서 M_white, M_black ≤ 50이므로 전체 시간복잡도는 실질적으로 O(2^50)보다 훨씬 작아 제한 시간 내 가능.

### 배운 점
<img width="244" height="148" alt="image" src="https://github.com/user-attachments/assets/1f3e4132-ddda-4bde-b49c-4a86b976cbc2" />

- 체스의 특성이 시간복잡도를 줄일 수 있었던 key였다
- 흰,검을 반반 나누면 2^50이 되면서 10초 내에 들어올 수 있게 된다. (안 나누면 전체 다 도니까 2^10)

시간복잡도 줄인 방법
1. `1 리스트 활용` : 1의 자리에 넣을지, 안 넣을지만 관리하면 돼서 시간복잡도를 줄일 수 있다.
    - 그런데 여기서 더 나아가, **체스의 흰 칸(벡터 whites), 검정칸(벡터 blacks)을 나누어서 관리**해야 했다.
    - 비솝은 대각선에만 영향을 미치므로 흰 칸, 검정 칸 끼리는 '독립사건'으로 관리해줘도 된다.
2. \ 방향 대각선 visited[r-c+N-1] , / 방향 대각선 visited[r+c] 활용
    - 지난번 배운 대각선 vis 처리 활용했다.
 
이제 dfs를 흰칸, 혹은 검정칸들의 1에 대한 리스트를 가능하다면 넣을 땐? 뺐을 땐? True,false 백트래킹 해주면 된다.
