### PR TITLE
Solved: [백트래킹] BOJ_비숍 김나영

### DIFF
--- a/백트래킹/나영/BOJ_1799_비숍.java
+++ b/백트래킹/나영/BOJ_1799_비숍.java
@@ -1,0 +1,53 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int n, ans;
+    static int [][] map;
+    static boolean [] leftVis, rightVis;
+    static List<int[]> white = new ArrayList<>();
+    static List<int[]> black = new ArrayList<>();
+    public static void main(String[] args) throws IOException {
+        n = Integer.parseInt(br.readLine());
+        map = new int [n][n];
+        leftVis = new boolean [2*n];
+        rightVis = new boolean [2*n];
+        
+        for (int r = 0; r < n; r++) {
+            st = new StringTokenizer(br.readLine());
+            for (int c = 0; c < n; c++) {
+                map[r][c] = Integer.parseInt(st.nextToken());
+                if (map[r][c] == 1) {
+                    if ((r + c) % 2 == 0) white.add(new int [] {r, c});
+                    else black.add(new int [] {r, c});
+                }
+            }
+        }
+
+        ans = dfs(white, 0) + dfs(black, 0);
+        
+        System.out.println(ans);
+    }
+
+    static int dfs(List<int []> list, int idx) {
+        if (idx == list.size()) return 0;
+
+        int r = list.get(idx)[0];
+        int c = list.get(idx)[1];
+        int max = 0;
+
+        // 이전 값에 의해 대각선 부분이 true 처리 되지 않았다면
+        if (!leftVis[r+c] && !rightVis[r-c+(n-1)]) {
+            leftVis[r+c] = rightVis[r-c+(n-1)] = true;
+            max = Math.max(max, 1 + dfs(list, idx + 1));
+            leftVis[r+c] = rightVis[r-c+(n-1)] = false;
+        }
+        
+        max = Math.max(max, dfs(list, idx + 1));
+
+        return max;
+    }
+}


### PR DESCRIPTION
### 자료구조
- 배열

### 알고리즘
- 백트래킹

### 시간복잡도
- 1의 개수가 m이라고 함
- white, black : O(2 ^ m1 + 2 ^ m2) = 최대 O(2 * (n^2 / 2))
- dfs : 모든 부분집합을 탐색 : O(2^(m/2) + 2^(m/2)) = O(2^(m/2)) = 최대 O(2 ^ (n^2 / 2))
- 최종 시간복잡도 : **O(2 ^ (n^2 / 2))**
- 하지만 비숍을 놓을 때마다 놓을 수 없는 위치가 생기고, 이를 vis로 체크하면서 가지치기하므로 최악까지는 가지 않는다.

### 배운점
첫 번째 벽
- N-QUEEN 처럼 이전 행의 queen의 위치를 for문을 돌려 체크하려고 했지만, 그럼 시간 초과 발생
- 그래서 leftVis, rightVis를 이용해 각 대각선의 방향에 따라 방문 배열을 생성해 O(1) 로 처리했다.

두 번째 벽
- 그럼에도 불구하고 시간 초과 발생,,,
- 이 문제를 체스처럼 생각했을 때, 흰 칸과 검은 칸은 서로 대각선에 영향을 미치지 않는다.
- 그래서 list에 1의 위치를 받을 때 (r + c) % 2로 현재 칸이 흰 칸인지 검은 칸인지 구분하면서 리스트를 두 개로 나누어 받았다.
- 그리고 dfs 시 리스트 별로 다르게 돌려 ans를 갱신했다.
- 따봉 플레야 고마워