### PR TITLE
Solved: [백트래킹] BOJ_근손실 홍지우

### DIFF
--- a/백트래킹/지우/BOJ_18429_근손실.cpp
+++ b/백트래킹/지우/BOJ_18429_근손실.cpp
@@ -1,0 +1,40 @@
+#include <iostream>
+#include <vector>
+
+using namespace std;
+
+int N, K;
+int ans = 0;
+vector<int> kit;
+vector<bool> vis;
+
+void dfs(int sIdx, int sum) {
+    if(sIdx == N) {
+        ans++;
+        return;
+    }
+
+    for(int i=0; i<N; i++) {
+        int nxtSum = sum - K + kit[i];
+        if(vis[i] || nxtSum < 500) continue;
+        
+        vis[i] = true;
+        
+        dfs(sIdx+1, nxtSum);
+        vis[i] = false;
+    }
+}
+
+int main() {
+    cin >> N >> K;
+    kit.resize(N, 0);
+    vis.resize(N, false);
+    for(int i=0; i<N; i++) {
+        cin >> kit[i];
+    }
+
+    dfs(0, 500);
+    cout << ans;
+    
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터

### 알고리즘
- 백트래킹

### 시간복잡도
1. DFS 깊이는 N이고, 각 단계에서 최대 N개의 분기가 있으므로 최악의 경우 시간복잡도는 O(N!).  
2. 각 경로마다 K와 kit 값을 사용해 계산하므로 각 호출의 연산은 O(1).  
3. 따라서 전체 시간복잡도는 O(N!)이고, N이 작을 때만 계산이 가능하다.  

### 배운 점
1 2 3 4
4 3 2 1 이 다르다고 보는 문제이다.
- vis를 활용하여 0~N까지 kit를 순회
- 만약 이전에 방문하지 않았거나 || kit를 썼을 때 500 밑으로 내려가지 않는다면? => kit 사용할 자격 충분~!
- 방문해서 관련하여 dfs(다음날 kit 쓰자굿!, 키트 적용 후의 다음 중량)
- 원상복구
