### PR TITLE
Solved: [백트래킹] BOJ_근손실 김나영

### DIFF
--- a/백트래킹/나영/BOJ_18429_근손실.java
+++ b/백트래킹/나영/BOJ_18429_근손실.java
@@ -1,0 +1,44 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int n, k, ans;
+    static int [] arr;
+    static boolean [] visited;
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        k = Integer.parseInt(st.nextToken());
+
+        arr = new int [n];
+        visited = new boolean [n];
+        st = new StringTokenizer(br.readLine());
+
+        for (int i = 0; i < n; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+        
+        dfs(0, 500, 0);
+        
+        System.out.println(ans);
+    }
+
+    static void dfs(int start, int sum, int cnt) {
+        if (cnt == n) {
+            if (sum >= 500) ans++;
+            return;
+        }
+
+        sum -= k;
+
+        for (int i = 0; i < n; i++) {
+            if (visited[i] || sum + arr[i] < 500) continue;
+            visited[i] = true;
+            dfs(i, sum + arr[i], cnt + 1);
+            visited[i] = false;
+        }
+    }
+}


### PR DESCRIPTION
### 자료구조
- 배열

### 알고리즘
- 백트래킹
- 순열

### 시간복잡도
- n개의 숫자에서 n개를 순서 생각하며 뽑음 => nPn = n!
- 최종 시간복잡도 : **O(n!)**

### 배운점
- k가 아니라 4를 넣고 풀어서 한 번 틀림,,, 껄껄
- 순서를 생각하며 뽑아야 하므로 **순열** 문제
- arr에서 하나씩 뽑고, 방문하지 않았거나, sum + arr[i] 가 500보다 큰 곳의 경우 visited 처리한 뒤 cnt == n이면 500보다 큰 지 확인