### PR TITLE
Solved: [백트래킹] BOJ_NM과 K (1) 홍지우

### DIFF
--- a/백트래킹/지우/BOJ_18290_NM과 K (1).cpp
+++ b/백트래킹/지우/BOJ_18290_NM과 K (1).cpp
@@ -1,0 +1,62 @@
+#include <iostream>
+#include <vector>
+#include <climits>
+
+using namespace std;
+
+int N, M, K;
+int ans = INT_MIN; // 음수가 들어올 수 있다.
+vector<vector<int>> maps;
+vector<vector<bool>> vis;
+
+int dr[] = {-1, 0, 1, 0};
+int dc[] = { 0, 1, 0, -1};
+
+bool inRange(int r, int c) {
+    return r>=0 && r<N && c>=0 && c<M;
+}
+
+bool notAdj(int r, int c) {
+    for(int d=0; d<4; d++) {
+        int nr = r + dr[d];
+        int nc = c + dc[d];
+        if(!inRange(nr,nc)) continue;
+        if(vis[nr][nc]) return false;
+    }
+    return true;
+}
+
+void dfs(int idx, int cnt, int sum) {
+    if(cnt == K) {
+        ans = max(ans, sum);
+        return;
+    }
+    if(idx == N*M) return;
+        
+    int r = idx/M;
+    int c = idx%M;
+    if(notAdj(r,c)) {
+        vis[r][c] = true;
+        dfs(idx+1, cnt+1, sum+maps[r][c]);
+        vis[r][c] = false;
+    }
+
+    dfs(idx+1, cnt, sum);
+}
+
+int main() {
+    cin.tie(0); cout.tie(0); ios::sync_with_stdio(0);
+    cin >> N >> M >> K;
+    maps.resize(N, vector<int>(M,0));
+    vis.resize(N, vector<bool>(M,false));
+
+    for(int r=0; r<N; r++) {
+        for(int c=0; c<M; c++) {
+            cin >> maps[r][c];
+        }
+    }
+
+    dfs(0, 0, 0);
+    cout << ans;
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터

### 알고리즘
- 백트래킹

### 시간복잡도
1. DFS 깊이는 최대 N×M이고, 각 위치에서 선택/비선택 두 가지 경우를 탐색하므로 최악의 경우 시간복잡도는 O(2^(N×M)).  
2. isAdj 함수는 인접 4칸을 검사하므로 호출당 O(1)의 상수 시간이 추가된다.  
3. 따라서 전체 시간복잡도는 O(2^(N×M))이며, N과 M이 작을 때만 완전탐색이 가능하다.  

### 배운 점
- 그냥 시작점을 여러 개 주고 대각선만 보며 나아갈지, 하나하나를 볼지 고민이 있었다. 
    - (근데 대각선만 보면 maps가 한 행으로만 이루어졌을 때, 한 칸 건너뛴 다음 칸을 볼 수 없게 된다.)
- 하나씩 Index를 옮기며 현재 r, c를 중심으로 가능 불가능 O, X를 판단했다.
- 만약 현재 r,c 인근 4방향에 vis된 것이 없으면 r,c는 가능!
    - r,c 방문체크 + 이거 바탕으로 dfs(다음 인덱스, cnt 하나 올림!, sum+현재 수)
    - 원상복구! (조건이 되더라도~ 다음 거가 더 좋을 수 있으니까~)
- (조건 안되는 경우 + 되더라도 다른 경우도 볼 거임) 현재는 선택 안 한 것으로 하고 dfs에 인덱스만 다음 걸로~

- **예외케이스**: 값에 음수도 들어갈 수 있다. ans 초기화를 제일 낮은 수로 해줘야 max(ans, _ )를 올바르게 할 수 있다.