### PR TITLE
Solved: [그래프탐색] BOJ_스타트링크 홍지우

### DIFF
--- a/그래프 탐색/지우/BOJ_5014_스타트링크.cpp
+++ b/그래프 탐색/지우/BOJ_5014_스타트링크.cpp
@@ -1,0 +1,52 @@
+#include <iostream>
+#include <algorithm>
+#include <vector>
+#include <queue>
+#include <unordered_set>
+
+using namespace std;
+
+int F, S, G, U, D;
+int ans = -1;
+queue<pair<int,int>> q;
+unordered_set<int> vis;
+
+void bfs() {
+    vis.insert(S);
+    q.push({S,0});
+
+    while(!q.empty()) {
+        auto [curr, cnt] = q.front(); q.pop();
+        if(curr == G) {
+            ans = cnt;
+            return;
+        }
+
+        int nxt = curr + U;
+        if(nxt > curr && nxt<= F && !vis.count(nxt)) {
+            vis.insert(nxt);
+            q.push({nxt, cnt+1});
+        }
+    
+        nxt = curr - D;
+        if(nxt < curr && nxt >= 1 && !vis.count(nxt)) {
+            vis.insert(nxt);
+            q.push({nxt, cnt+1});
+        }
+    }
+}
+
+int main() {
+    cin.tie(0); cout.tie(0); ios::sync_with_stdio(0);
+    
+    cin >> F >> S >> G >> U >> D;
+    bfs();
+    
+    if(ans == -1) {
+        cout << "use the stairs";
+    } else {
+        cout << ans;
+    }
+    
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- Queue, unordered_set

### 알고리즘
- 그래프탐색

### 시간복잡도
BFS 시간복잡도
- 각 층을 최대 1번만 방문하므로 방문 횟수는 O(F)
- 각 방문마다 최대 2개의 이동(U, D)만 검사 → O(2F) = O(F)
- 전체 시간복잡도는 O(F), F ≤ 70,803이면 1초 내 처리 가능

➕ DFS 시간복잡도
- 같은 층을 여러 경로로 재방문할 수 있어 최악의 경우 모든 경로 탐색
- 깊이는 최대 F, 분기 최대 2 → O(2^F) 수준까지 폭발 가능
- 실질적으로 백트래킹 해도 중복 경로가 많아 BFS 대비 훨씬 비효율적, 큰 F에서는 TLE

### 배운 점
- 1 ≤ S, G ≤ F ≤ 1000000, 0 ≤ U, D ≤ 1000000 <- 백만을 봤을 때. 난 알아야 했다. 이 문제는 BFS라는 걸.
- DFS로 풀었더니 백트래킹 과정 때문에 아무리 노력해도 시간 내에 들어오지 않는다는 걸 깨달았다.
    - +, -, -. - (-,+,-,- / --+- ..)의 조합이 결국 같은 경우의 수를 의미하는데 이것을 줄일 방법이 없어 쎄함을 느꼈다.
- BFS로 바꾸어 처음부터 양방향으로 움직이며 같은 수를 방문하지 않으면서 가장 빠르게 위치점에 도달한 curr의 cnt를 인출했다. 