### PR TITLE
Solved: [백트래킹] BOJ_행운의 문자열 김나영

### DIFF
--- a/백트래킹/나영/BOJ_1342_행운의 문자열.java
+++ b/백트래킹/나영/BOJ_1342_행운의 문자열.java
@@ -1,0 +1,37 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static int ans;
+    static char[] charn;
+    static int [] cnt;
+    static List<Character> list = new ArrayList<>();
+    public static void main(String[] args) throws IOException {
+        charn = br.readLine().toCharArray();
+        cnt = new int [26];
+
+        for (char c : charn) {
+            cnt[c - 'a']++;
+        }
+
+        find(-1, 0);
+        
+        System.out.println(ans);
+    }
+
+    static void find(int prev, int depth) {
+        if (depth == charn.length) {
+            ans++;
+            return;
+        }
+        
+        for (int i = 0; i < 26; i++) {
+            if (cnt[i] == 0 || prev == i) continue;
+            cnt[i]--;
+            find(i, depth + 1);
+            cnt[i]++;
+        }
+    }
+}


### PR DESCRIPTION
### 자료구조
- 배열

### 알고리즘
- 백트래킹

### 시간복잡도
- 최대 상태 수 = 문자열 길이 n × 알파벳 수(26) → O(26^n) 개의 상태 가능
- 실제로는 cnt 배열로 중복을 제한하므로 최대 시간복잡도는 O(n!)에 가까움

### 배운점
- 원래는 모든 문자열의 순열을 탐색하면서 prev를 파라미터로 받아 이전 값과 현재 값이 동일하지 않도록 한 뒤, 값을 set에 넣어 이미 사용한 문자열이면 카운팅하지 않는 방식을 썼는데 그럼 10자리에서 터졌다
- 그래서 cnt 배열을 이용해 알파벳의 개수를 센 뒤 재귀를 돌 때 이전 알파벳 인덱스 = prev와 현재 인덱스가 같거나 사용할 수 없는 알파벳이면 continue하고, 아니면 해당 알파벳 개수를 뺀 뒤 재귀를 돌렸다.