### PR TITLE
Solved: [백트래킹] BOJ_스타트와 링크 홍지우

### DIFF
--- a/백트래킹/지우/BOJ_14889_스타트와 링크.cpp
+++ b/백트래킹/지우/BOJ_14889_스타트와 링크.cpp
@@ -1,0 +1,67 @@
+#include <iostream>
+#include <vector>
+#include <unordered_set>
+#include <cmath>
+#include <climits>
+
+using namespace std;
+
+int N;
+int ans = INT_MAX;
+vector<vector<int>> power;
+vector<bool> vis;
+
+void dfs(int s, int pIdx) {
+    if(pIdx == N/2) {
+        vector<bool> vis2(N+1, false);
+        
+        for(int i=1; i<=N; i++) {
+            if(!vis[i]) vis2[i] = true;
+        }
+
+        int team1 = 0;
+        int team2 = 0;
+
+        for(int r=1; r<=N-1; r++) {
+            for(int c=r+1; c<=N; c++) {
+                if(vis[r] && vis[c]) {
+                    team1 += power[r][c] + power[c][r];
+                }
+                if(vis2[r] && vis2[c]) {
+                    team2 += power[r][c] + power[c][r];
+                }
+            }
+        }
+
+        ans = min(ans, abs(team1-team2));
+        if(ans == 0) {
+            cout << ans; 
+            exit(0);
+        } 
+        
+    }
+
+    for(int i=s; i<=N; i++) {
+        if(!vis[i]) {
+            vis[i] = true;
+            dfs(i+1, pIdx+1);
+            vis[i] = false;
+        }
+    }
+}
+
+int main() {
+    cin.tie(0); cout.tie(0); ios::sync_with_stdio(0);
+    cin >> N;
+    power.resize(N+1, vector<int>(N+1,0));
+    vis.resize(N+1, false);
+    for(int r=1; r<=N; r++) {
+        for(int c=1; c<=N; c++) {
+            cin >> power[r][c];
+        }
+    }
+
+    dfs(1,0);
+    cout << ans;
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터

### 알고리즘
- 백트래킹

### 시간복잡도
- 팀 조합은 N명 중 절반(N/2명)을 고르는 경우의 수 → O(2^N) 혹은 정확히는 O(N **C** N/2)
- 각 조합마다 팀 능력치 계산에 O(N^2) 소요
- 총 시간복잡도는 O(N^2 * N **C**  N/2)

### 배운 점
- 시간복잡도를 줄인 2 가지 방법
1. 이 문제는 '조합' 문제다. 팀1, 팀2가 결정된 후 능력치 계산할 때 ( r, c ) 가 완전히 겹치지 않는 조합으로 계산되게끔 함
``` 
(이전)
for(int r=1; r<=N; r++) {
            for(int c=1; c<=N; c++) {


(이후)
for(int r=1; r<=N-1; r++) {
            for(int c=r+1; c<=N; c++) {
```

2. unordered_set에서 Vis 배열로 바꿈
- 코드는 통과했으나 1412ms 걸려서 너무 오래 걸리는 것 같았음
- O(1) 이라 되겠지~ 싶었는데 아래와 같은 이유로 느려짐
    - unordered_set도 결국 해시 계산 → 버킷 접근 → 충돌 체인 처리 과정을 거침
    → 단순 vector<bool> 같은 인덱스 접근보다 훨씬 오버헤드가 큼
- vis 배열로 바꾸니까 188ms 달성 ⭐ 