### PR TITLE
Solved: [백트래킹] BOJ_스타트와 링크 김나영

### DIFF
--- a/백트래킹/나영/BOJ_14889_스타트와 링크.java
+++ b/백트래킹/나영/BOJ_14889_스타트와 링크.java
@@ -1,0 +1,48 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int n, ans=1000;
+    static int [][] map;
+    static boolean[] selected;
+    public static void main(String[] args) throws IOException {
+        n = Integer.parseInt(br.readLine());
+        map = new int [n] [n];
+        selected = new boolean [n];
+        for (int r = 0; r < n; r++) {
+            st = new StringTokenizer(br.readLine());
+            for (int c = 0; c < n; c++) {
+                map[r][c] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        dfs(0, 0);
+        System.out.println(ans);
+    }
+
+    static void dfs (int start, int cnt) {
+        if (cnt == n/2) {
+            int team1 = 0, team2 = 0;
+            for (int i = 0; i < n; i++) {
+                for (int j = i+1; j < n; j++) {
+                    if (selected[i] && selected[j]) team1 += map[i][j] + map[j][i];
+                    else if (!selected[i] && !selected[j]) team2 += map[i][j] + map[j][i];
+                }
+            }
+            
+            ans = Math.min(ans, Math.abs(team1-team2));
+            return;
+        }
+
+        if (start == n) return;
+
+        for (int i = start; i < n; i++) {
+            selected[i] = true;
+            dfs(i+1, cnt+1);
+            selected[i] = false;
+        }
+    }
+}


### PR DESCRIPTION
### 자료구조
- 배열

### 알고리즘
- 브루트포스
- 백트래킹

### 시간복잡도
- 전체 n명 중 n/2 명을 뽑는 조합 : n C n/2 = O(2^n)에 가까움
- cnt == n/2 일 때 두 팀의 능력치 계산 : 최대 O(n^2)
- 최종 시간복잡도 : **O(2^n * n^2)**

### 배운점
- dfs 돌릴 때 선택된 배열 자체를 들고 다니면서 계산하려고 했는데, 갑자기 boolean으로 급선회
    - 이것도 되긴 할듯,,?
- 조합 탐색하면서, cnt == n/2가 되면 selected 배열에 선택된 사람/선택되지 않은 사람 기준으로 각 팀의 능력치를 계산해 가장 적은 차이를 ans에 갱신한다.