### PR TITLE
Solved: [그래프 탐색] BOJ_트리 김나영

### DIFF
--- a/그래프 탐색/나영/BOJ_1068_트리.java
+++ b/그래프 탐색/나영/BOJ_1068_트리.java
@@ -1,0 +1,48 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int n, k, ans;
+    static boolean [] deleted;
+    static List<Integer> [] list;
+    public static void main(String[] args) throws IOException {
+        n = Integer.parseInt(br.readLine());
+        list = new ArrayList [n];
+        deleted = new boolean [n];
+
+        for (int i = 0; i < n; i++) {
+            list[i] = new ArrayList<>();
+        }
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            int a = Integer.parseInt(st.nextToken());
+            if (a >= 0) list[a].add(i);
+        }
+        
+        k = Integer.parseInt(br.readLine());
+
+        dfs(k);
+
+        for (int i = 0; i < n; i++) {
+            if (deleted[i]) continue;
+            boolean isS = true;
+            for (int j : list[i]) {
+                if (!deleted[j]) isS = false;
+            }
+            if (isS) ans++;
+        }
+        
+        System.out.println(ans);
+    }
+
+    static void dfs (int idx) {
+        deleted[idx] = true;
+        for (int i : list[idx]) {
+            dfs(i);
+        }
+    }
+}


### PR DESCRIPTION
### 자료구조
- ArrayList
- 배열

### 알고리즘
- 그래프 탐색
- DFS

### 시간복잡도
- DFS : 최악의 경우 모든 노드 탐색 = O(n)
- 리프 노드 체크 : 모든 노드를 돌며 자식 노드를 확인 = 모든 간선의 수 = n-1 = O(n)
- 최종 시간복잡도 : **O(n)**

### 배운점
- 리프 노드를 sum으로 미리 구해두고 dfs로 노드 삭제 시 해당 노드가 자식이 없는 리프 노드이면 sum--하는 방식을 썼는데, 그럼 삭제된 노드의 부모 노드가 리프 노드가 되는 경우의 수를 구할 수 없었다.
- 그래서 deleted 배열을 통해 dfs 시 삭제되는 노드를 체크하고, 이후 for문으로 리프 노드의 개수를 구할 때 만약 해당 노드가 deleted 되지 않았고, 자식 노드가 없거나/모두 삭제된 경우 ans++ 하는 방식으로 바꿨다. 헤헷!
- 꼼꼼하게 체크하는 버릇,, 들여야 한다~!!