### PR TITLE
Solved: [그래프 탐색] BOJ_트리 홍지우

### DIFF
--- a/그래프 탐색/지우/BOJ_1068_트리.cpp
+++ b/그래프 탐색/지우/BOJ_1068_트리.cpp
@@ -1,0 +1,52 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+
+using namespace std;
+
+int N; int off;
+int root;
+vector<vector<int>> childs;
+
+int bfs(int v) {
+    int leaf = 0;
+    queue<int> q; 
+    q.push(v);
+
+    while(!q.empty()) {
+        int curr = q.front(); q.pop();
+
+        bool hasChild = false;
+        for(int c : childs[curr]) {
+            if(c == off) continue;
+            hasChild = true;
+            q.push(c);
+        }
+
+        if(!hasChild) leaf++;
+    }
+
+    return leaf;
+}
+
+int main() {
+    cin >> N;
+    childs.resize(N);
+    for(int i=0; i< N; i++) {
+        int parent = 0; cin >> parent;
+        if(parent == -1) {
+            root = i;
+        } else {
+            childs[parent].push_back(i);
+        }
+    }
+    cin >> off;
+    if(root == off) {
+        cout << 0;
+        return 0;
+    }
+    
+    childs[off].clear();
+    cout << bfs(root);
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터, 큐

### 알고리즘
- 그래프 탐색

### 시간복잡도
- 트리에서 모든 노드를 한 번씩 탐색 → O(N)
- 각 노드의 자식 리스트를 순회하는 연산도 전체적으로 O(N)
- 총 시간복잡도는 O(N)

### 배운 점
- 처음에 bfs(root) - bfs(off) 를 하여 문제를 풀려고 했다.
    - 문제: 트리가 1-2-3-4 이렇게 되어 있을 때 3을 날려도 Leaf는 하나인데 이 케이스를 반영하지 못한다.
- 해결: 밑에 자식이 있는지 판별하는 로직을 세움
    - 자식이 없거나, off 이면 hasChild = false가 된다. 그럼 Leaf 라는 뜻이므로 leaf++;