### PR TITLE
Solved: [그래프 탐색] BOJ_경쟁적 전염 홍지우

### DIFF
--- a/그래프 탐색/지우/BOJ_18405_경쟁적 전염.cpp
+++ b/그래프 탐색/지우/BOJ_18405_경쟁적 전염.cpp
@@ -1,0 +1,53 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+#include <tuple>
+
+using namespace std;
+
+int N, K;
+int S, X, Y;
+vector<vector<int>> maps;
+priority_queue<tuple<int,int,int>, vector<tuple<int,int,int>>, greater<tuple<int,int,int>>> pq;
+
+int dr[] = {1,0,-1,0};
+int dc[] = {0,-1,0,1};
+
+bool inRange(int r, int c) {
+    return r>=0 && r<N && c>=0 && c<N;
+}
+
+void bfs() {
+    while(S--) {
+        priority_queue<tuple<int,int,int>, vector<tuple<int,int,int>>, greater<tuple<int,int,int>>> pq2;
+        while(!pq.empty()) {
+            auto[num, r, c] = pq.top(); pq.pop();
+
+            for(int d=0; d<4; d++) {
+                int nr = r + dr[d]; int nc = c + dc[d];
+                if(inRange(nr,nc) && maps[nr][nc] == 0) {
+                    maps[nr][nc] = num;
+                    pq2.push({num, nr, nc});
+                }
+            }
+        }
+        pq = pq2;
+    }
+}
+
+int main() {
+    cin >> N >> K;
+    maps.resize(N, vector<int>(N,0));
+
+    for(int r=0; r<N; r++) {
+        for(int c=0; c<N; c++) {
+            cin >> maps[r][c];
+            if(maps[r][c] > 0) pq.push({maps[r][c], r,c});
+        }
+    }
+    cin >> S >> X >> Y;
+    
+    bfs();
+    cout << maps[X-1][Y-1];
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터, Priority_Queue

### 알고리즘
- 그래프 탐색

### 시간복잡도
- BFS는 최대 S초 동안 수행되며, 각 초마다 O(N^2)개의 칸을 큐에서 처리 가능
- 각 칸은 최대 한 번만 감염되므로 전체 확산 과정은 O(N^2)
- 총 시간복잡도는 O(N^2 + K log K) (초기 우선순위 큐 정렬 포함)

### 배운 점
- `단, 매 초마다 번호가 낮은 종류의 바이러스부터 먼저 증식한다.` => PQ 사용했다.
- S가 0초가 될 때까지 -- 하며 whlie문 돌린다.
    - 다음 전염될 pq를 저장하기 위해 pq2를 선언한다.
    - pq 모두 털어준다.
        - 무조건 낮은 수부터 나오게 된다. 그걸 중심으로 4방향 돌려서 0 이면 전염되게 한다.
    - pq2가 이제 털어야 할 차례이니 pq로 옮겨준다. (pq2는 22번 줄에서 다시 초기화 됨)
