### PR TITLE
Solved: [백트래킹] BOJ_부등호 홍지우

### DIFF
--- a/백트래킹/지우/BOJ_2529_부등호.cpp
+++ b/백트래킹/지우/BOJ_2529_부등호.cpp
@@ -1,0 +1,54 @@
+#include <iostream>
+#include <vector>
+
+using namespace std;
+
+int k;
+string maxAns = "";
+string minAns = "99999999999";
+vector<bool> vis;
+vector<char> signs;
+
+void dfs(int signIdx, int pIdx, string num, int currNum) {
+    if(pIdx == k) {
+        maxAns = max(maxAns, num); 
+        minAns = min(minAns, num);
+        return;
+    }
+
+    char currSign = signs[signIdx];
+
+    for(int i=0; i<=9; i++) {
+        if(!vis[i]) {
+            if(currSign == '>' && currNum > i) {
+                vis[i] = true;
+                dfs(signIdx+1, pIdx+1, num + to_string(i) , i);
+                vis[i] = false;
+            }
+            if(currSign == '<' && currNum < i) {
+                vis[i] = true;
+                dfs(signIdx+1, pIdx+1, num + to_string(i) , i);
+                vis[i] = false;
+            }
+        }
+    }
+}
+
+int main() {
+    cin >> k;
+    vis.resize(10, false);
+    signs.resize(k+1, '\0');
+
+    for(int i=0; i<k; i++) {
+        cin >> signs[i];
+    }
+
+    for(int i=0; i<=9; i++) {
+        vis[i] = true;
+        dfs(0, 0, to_string(i), i);
+        vis[i] = false;
+    }
+
+    cout << maxAns << "\n" << minAns;
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- String , 벡터

### 알고리즘
- 백트래킹

### 시간복잡도
- 백트래킹으로 가능한 숫자 조합을 전부 탐색 → 최대 O(10! = 3628800)
- 하지만 부등호 조건과 방문 체크로 가지치기 수행 → 실제 탐색은 O(P(10, k+1))
- 총 시간복잡도는 O(P(10, k+1)) = O(10 x 9 x 8 ... (10 - k))

### 배운 점
- [ `1 <` `2 <` `3 < `4 ] 이런 식으로 묶어서 dfs 돌려줬다.
    - currNum  < **' _다음 숫자 **i**_ '**

- 처음엔 그냥 num*10 + i 이런 식으로 숫자 자체를 넘기려고 했는데 -> 그럼 021 이 21로 나온다 (일단 int형 안에도 안 들어감)
- ➡️ string 자체를 넘겨줬다.
- 또한, string 안에서도 사전순으로 대소 비교가 가능함을 이용해 min, max를 활용해 대소비교를 해줬다.
