### PR TITLE
Solved: [그래프 탐색] BOJ_점프 게임 홍지우

### DIFF
--- a/그래프 탐색/지우/BOJ_15558_점프 게임.cpp
+++ b/그래프 탐색/지우/BOJ_15558_점프 게임.cpp
@@ -1,0 +1,67 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+#include <tuple>
+
+using namespace std;
+
+int N, k;
+int removeIdx = 0;
+vector<vector<int>> maps;
+vector<vector<bool>> vis;
+queue<tuple<int,int,int>> q;
+
+bool inRange(int r, int c) {
+    return r>=0 && r<N && c>=0 && c<N;
+}
+
+int bfs () {
+    while(!q.empty()) {
+
+        auto[r, c, t] = q.front(); q.pop();
+
+        if(c < t) continue; // 현재 위치 c가 시간보다 뒤에 있으면? -> 불가능
+        
+        int nr = 1-r;
+        int nc = c+k;
+        if(nc >= N) {
+            return 1;
+        } else if(inRange(nr,nc) && !vis[nr][nc] && maps[nr][nc] == 1) {
+            vis[nr][nc] = true;
+            q.push({nr,nc, t+1});
+        }
+
+        for(int i=-1; i<=1; i+=2) {
+            nr = r;
+            nc = c + i;
+            
+            if(nc >= N) {
+                return 1;
+            } else if(inRange(nr,nc) && !vis[nr][nc] && maps[nr][nc] == 1) {
+                vis[nr][nc] = true;
+                q.push({nr,nc,t+1});
+            }
+        }
+    }
+
+    return 0;
+}
+
+int main() {
+    cin >> N >> k;
+    maps.resize(2, vector<int>(N,0));
+    vis.resize(2, vector<bool>(N,false)); 
+    
+    for(int r=0; r<2; r++) {
+        string s; cin >> s;
+        for(int c=0; c<N; c++) {
+            maps[r][c] = s[c] - '0';
+        }
+    }
+
+    vis[0][0] = true;
+    q.push({0,0,0});
+    cout << bfs();
+    
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터, 큐

### 알고리즘
- 그래프 탐색

### 시간복잡도
- BFS로 각 칸을 최대 한 번씩 방문하므로 탐색 비용은 O(N)
- 각 위치에서 최대 3가지 방향으로 이동 시도 → O(1)
- 총 시간복잡도는 O(N)

### 배운 점
- 처음에 이동방식이 다르면 공간을 다르게 설정해둬야 한다고 생각해서 3차원 공간을 뒀는데 그럴 필요가 없었다. 어차피 애들은 시간이 흐르며 쭉 나아가면 되는 그냥 일반 그래프 탐색 문제이다. 같은 칸에서 다음 이동까지 탐색은 같게 진행됨.
    - 말되원 같은 문제는 남은 K가 몇 번인지에 따라 갈 수 있는 경로 자체가 달라짐 (경로 순서대로 생각해봤을 때) 

- 시간에 따라 vis 공간을 다르게 설정하고자 했다. 그러니까 메모리 초과. 시간에 따라 갈 수 있는 map 자체는 모든 애들이 다 똑같다.
    - 그냥 현재 위치가 무조건 Time이랑 같거나 앞서게끔 설정했다.  c(현재 위치) < time 이면 out

- 현재 위치 기준으로 3가지 방법을 시도하여 c(현재 위치)가 범위를 벗어나면 -> 1 / 아니면 다음으로 넘어가서 다시 q에 넣어주기(이때 시간은 +1)
