### PR TITLE
Solved: [그래프 탐색] BOJ_뱀과 사다리 게임 김나영

### DIFF
--- a/그래프 탐색/나영/BOJ_16928_뱀과 사다리 게임.java
+++ b/그래프 탐색/나영/BOJ_16928_뱀과 사다리 게임.java
@@ -1,0 +1,64 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int n, m, cnt;
+    static boolean [] visited;
+    static Map<Integer, Integer> ladder = new HashMap<>();
+    static Map<Integer, Integer> snake = new HashMap<>();
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        visited = new boolean [101];
+
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            ladder.put(a, b);
+        }
+        
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            snake.put(a, b);
+        }
+
+        visited[1] = true;
+        System.out.println(bfs());
+    }
+
+    static int bfs () {
+        Queue <int[]> que = new LinkedList<>();
+        que.offer(new int[] {1, 0});
+
+        while (!que.isEmpty()) {
+            int [] q = que.poll();
+            if (q[0] == 100) return q[1];
+
+            for (int i = 1; i <= 6; i++) {
+                int nr = q[0] + i;
+                if (nr > 100 || visited[nr]) continue;
+                while(true) {
+                    visited[nr] = true;
+                    if (ladder.containsKey(nr)) {
+                        nr = ladder.get(nr);
+                    } else if (snake.containsKey(nr)) {
+                        nr = snake.get(nr);
+                    } else break;
+                }
+
+                que.offer(new int [] {nr, q[1] + 1});
+            }
+        }
+
+        return 0;
+    }
+}


### PR DESCRIPTION
### 자료구조
- HashMap
- Queue
- 배열

### 알고리즘
- 그래프 탐색
- BFS

### 시간복잡도
- 방문 가능한 칸의 개수 = 100
- 1~6까지 주사위를 돌리며 말을 이동 = 6
- 최종 시간복잡도 : **O(100 * 6) = O(600)**

### 배운점
- 문제의 핵심은 **뱀과 사다리를 얼마나 탈 수 있느냐** 이다
- 각 칸에는 뱀 하나, 사다리 하나를 놓을 수 있다 => 사다리를 타고 도착한 칸에 또 다른 사다리나 뱀이 있을 수 있다
- 이를 명시하고 현재 인덱스 + 주사위 수 = nr을 구한 뒤 nr 위치에 뱀/사다리가 있다면 while 문으로 다음 칸으로 넘기며 그 다음 칸에도 뱀과 사다리가 있는지 확인하며 없을 때까지 탐색한다

<img width="200" height="200" alt="image" src="https://github.com/user-attachments/assets/bcfd46ad-45e9-4939-ba09-551d6ad7faf5" />
