### PR TITLE
Solved: [그래프 탐색] BOJ_뱀과 사다리 게임 홍지우

### DIFF
--- a/그래프 탐색/지우/BOJ_16928_뱀과 사다리 게임.cpp
+++ b/그래프 탐색/지우/BOJ_16928_뱀과 사다리 게임.cpp
@@ -1,0 +1,63 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+#include <map>
+
+using namespace std;
+
+int N, M;
+int ans = 101;
+map<int,int> m;
+vector<bool> vis;
+queue<pair<int,int>> q;
+
+void bfs () {
+    vis[1] = true;
+    q.push({1, 0});
+
+    while(!q.empty()) {
+        auto [pos, cnt] = q.front(); q.pop();
+
+        if(pos == 100) {
+            ans = cnt;
+            return;
+        }
+        
+        if(pos > 100) continue;
+
+        for(int i=1; i<=6; i++) {
+            int nxt = pos + i;
+
+            if(vis[nxt]) continue;
+            
+            if(m.find(nxt) != m.end()) {
+                q.push({m[nxt], cnt+1});
+            } else {
+                vis[nxt] = true;
+                q.push({nxt, cnt+1});
+            }
+        }
+    }
+}
+
+int main() {
+    cin >> N >> M;
+    vis.resize(101,false);
+    for(int i=0; i<N; i++) {
+        int x, y;
+        cin >> x >> y;
+
+        m.insert({x, y});
+    }
+
+    for(int i=0; i<M; i++) {
+        int u, v;
+        cin >> u >> v;
+        
+        m.insert({u, v});
+    }
+
+    bfs();
+    cout << ans;
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 큐, 벡터, map
- map.insert({key, value}); if(map.find(key) != map.end())

### 알고리즘
- 그래프 탐색

### 시간복잡도
- 주사위 범위(1~6) 내에서 100칸까지 탐색하므로 BFS는 O(100)
- 각 칸에서 사다리/뱀 여부를 map에서 조회 → O(log N) (map 사용 시)
- 총 시간복잡도는 O(100 * log(N + M)) = O(600) 수준 (실질적으로 매우 빠름)

### 배운 점
- 처음에 주사위 돌리는 걸 까먹고 visited를 안 썼다가 예외케이스 시간 돌아가는 거 보고 다시 추가함 헤헷
- PQ를 사용해서 가장 pos가 큰 것부터 인출하여 처리하려고 했으나 min(ans, cnt) 과정이 들어갈 수 밖에 없어 dfs 처럼 모두 돌게 된다. 
    - 중요한 것은 cnt가 가장 작은 것이라  가장 최소의 cnt 에서 100을 발견할 수 있는 그냥 q를 쓰는게 맞았음
- 사다리, 뱀에 대한 vis 처리를 미리 해두면 나중에 정상적으로 오면서 해당 위치를 방문했을 땐 그냥 사다리 타지도 않았는데 이미 방문한 것으로 처리가 되어버려서 해당 부분 vis 되었는지 체크하는 것은 뺐다.