### PR TITLE
Solved: [백트래킹] BOJ_1, 2, 3 더하기 2 김나영

### DIFF
--- a/백트래킹/나영/BOJ_12101_1, 2, 3 더하기 2.java
+++ b/백트래킹/나영/BOJ_12101_1, 2, 3 더하기 2.java
@@ -1,0 +1,41 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static StringBuilder sb = new StringBuilder();
+    static Scanner sc = new Scanner(System.in);
+    static int n, k, cnt;
+    public static void main(String[] args) {
+        n = sc.nextInt();
+        k = sc.nextInt();
+
+        dfs(0, new ArrayList<>());
+        System.out.println(-1);
+    }
+
+    static void dfs (int sum, List<Integer> list) {
+        if (sum > n) return;
+        if (sum == n) {
+            cnt++;
+            if (cnt == k) {
+                for (int i = 0; i < list.size(); i++) {
+                    if (i == list.size()-1) sb.append(list.get(i));
+                    else sb.append(list.get(i)).append("+");
+                }
+                
+                System.out.println(sb.toString());
+                System.exit(0);
+            }
+
+            return;
+        }
+
+        for (int i = 1; i < 4; i++) {
+            list.add(i);
+            dfs(sum + i, list);
+            
+            list.remove(list.size()-1);
+        }
+    }
+}


### PR DESCRIPTION
### 자료구조
- ArrayList
- 배열

### 알고리즘
- 브루트포스
- 백트래킹

### 시간복잡도
- 매 단계에서 1, 2, 3의 선택지가 존재
- 이 때, dfs의 깊이는 최대 n이 될 수 있음 => 최악의 시간복잡도 : O(3^n)
- 실제로는 sum이 n이 될 때까지만 돌고 끊으므로 피보나치 수열로 생각했을 때 O(f(n) ≈ O(1.84n)이라고 함
    - 그래서 이 문제는 dp로도 가능,, 근데 코드가 개 복잡해서 시간복잡도를 정말 줄이고 싶으면 가능할 듯,, dp의 시간복잡도는 무려 O(n)이라고 합니다

### 배운점
- 중복을 허용하는 순열을 1, 2, 3 숫자 중에서 제한 없이 뽑아서 돌리되, 해당 숫자들의 합이 n 이상이면 끊고 n이면 cnt에 순서를 더한다.
- 그리고 cnt == k가 되면 dfs의 list에 담아 놓은 숫자들을 꺼내 일정한 형태로 출력한다.

그럼 자쟌- 멋진 결과물 완성!

<img width="299" height="169" alt="image" src="https://github.com/user-attachments/assets/226ab87b-e58d-4047-b4c1-2087d2fd74fe" />
