### PR TITLE
Solved: [그래프 탐색] BOJ_보물섬 김나영

### DIFF
--- a/그래프 탐색/나영/BOJ_2589_보물섬.java
+++ b/그래프 탐색/나영/BOJ_2589_보물섬.java
@@ -1,0 +1,70 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int n, m, ans;
+    static char map [][];
+    static boolean visited [][];
+    static int [] dr = {-1, 0, 1, 0};
+    static int [] dc = {0, -1, 0, 1};
+    static class P {
+        int r, c, cnt;
+
+        P (int r, int c, int cnt) {
+            this.r = r;
+            this.c = c;
+            this.cnt = cnt;
+        }
+    }
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        map = new char [n][];
+        
+        for (int i = 0; i < n; i++) {
+            map[i] = br.readLine().toCharArray();
+        }
+
+        for (int r = 0; r < n; r++) {
+            for (int c = 0; c < m; c++) {
+                visited = new boolean [n][m];
+                if (map[r][c] == 'L') {
+                    bfs(r, c);
+                }
+            }
+        }
+
+        System.out.println(ans);
+    }
+
+    static void bfs(int r, int c) {
+        Queue<P> que = new LinkedList<>();
+        visited[r][c] = true;
+        que.offer(new P (r, c, 0));
+
+        while (!que.isEmpty()) {
+            P p = que.poll();
+
+            if (ans < p.cnt) ans = p.cnt;
+
+            for (int d = 0; d < 4; d++) {
+                int nr = p.r + dr[d];
+                int nc = p.c + dc[d];
+
+                if (check(nr, nc) && map[nr][nc] == 'L' && !visited[nr][nc]) {
+                    visited[nr][nc] = true;
+                    que.offer(new P (nr, nc, p.cnt+1));
+                }
+            }
+        }
+    }
+
+    static boolean check(int r, int c) {
+        return r >= 0 && r < n && c >= 0 && c < m;
+    }
+}


### PR DESCRIPTION
### 자료구조
- Queue
- 배열

### 알고리즘
- 그래프 탐색
- BFS

### 시간복잡도
- 모든 칸이 육지인 경우 BFS 시 n*m개의 칸을 탐색
- for 문에서도 모든 칸에 대해 BFS 실행
- 최종 시간복잡도 : **O((n * m)^2)**

### 배운점
- visited를 써야 했던 문제,,, 싫다 배열 하나 더 느는 거
- **가장 먼 거리에 있는 두 섬의 거리** 를 구해야 하므로 모든 섬을 시작점으로 BFS 탐색해야 함
- 또한, 모든 섬에 대해 너비 우선 탐색 진행하므로 map의 상태를 바꾸면 안 된다 => visited 배열 등장