### PR TITLE
Solved: [백트래킹] BOJ_영재의 시험 김나영

### DIFF
--- a/백트래킹/나영/BOJ_19949_영재의 시험.java
+++ b/백트래킹/나영/BOJ_19949_영재의 시험.java
@@ -1,0 +1,39 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int ans;
+    static int [] arr = new int [10];
+    static int [] arr2 = new int [10];
+    static void dfs (int depth) {
+        if (depth == 10) {
+            int cnt = 0;
+            for (int i = 0; i < 10; i++) {
+                if (arr[i] == arr2[i]) cnt++;
+            }
+
+            if (cnt >= 5) ans++;
+            return;
+        }
+
+        for (int i = 1; i < 6; i++) {
+            if (depth >= 2 && (arr2[depth - 2] == i && arr2[depth - 1] == i)) continue;
+            arr2[depth] = i;
+            dfs(depth+1);
+        }
+    }
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+
+        for (int i = 0; i < 10; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        dfs(0);
+        
+        System.out.println(ans);
+    }
+}


### PR DESCRIPTION
### 자료구조
- 배열

### 알고리즘
- 백트래킹

### 시간복잡도
- 5개의 숫자에서 중복 허용 10개의 수를 뽑음 => 5^10
- 3자리에 같은 수가 연속으로 나오는 경우를 제외하면 5^10 까지 가지는 않지만, 상수 비율
- 최종 시간복잡도 : **O(5^10)**

### 배운점
- 중복 허용 순열 추출하는 문제
- 이 때 3자리 연속된 수가 모두 같은 경우만 제외시켰다