### PR TITLE
Solved: [그래프 탐색] BOJ_DSLR 김나영

### DIFF
--- a/그래프 탐색/나영/BOJ_9019_DSLR_1.java
+++ b/그래프 탐색/나영/BOJ_9019_DSLR_1.java
@@ -1,0 +1,81 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int T, x, y;
+    static boolean [] visited;
+    static StringBuilder sb = new StringBuilder();
+    static class P {
+        int a;
+        String ans;
+
+        P(int a, String ans) {
+            this.a = a;
+            this.ans = ans;
+        }
+    }
+    
+    public static void main(String[] args) throws IOException {
+        T = Integer.parseInt(br.readLine());
+
+        for (int t = 0; t < T; t++) {
+            visited = new boolean [10000];
+            st = new StringTokenizer(br.readLine());
+            x = Integer.parseInt(st.nextToken());
+            y = Integer.parseInt(st.nextToken());
+
+            visited[x] = true;
+
+            bfs();
+        }
+        
+        System.out.println(sb.toString());
+    }
+
+    static void bfs() {
+        Queue<P> que = new LinkedList<>();
+        que.offer(new P (x, ""));
+
+        while (!que.isEmpty()) {
+            P p = que.poll();
+
+            if (p.a == y) {
+                sb.append(p.ans).append("\n");
+                return;
+            }
+
+            int n = p.a;
+
+            int nr = n*2 % 10000;
+            if (!visited[nr]) {
+                que.offer(new P (nr, p.ans + "D"));
+                visited[nr] = true;
+            }
+
+            nr = n - 1 < 0 ? 9999 : n - 1;
+            if (!visited[nr]) {
+                que.offer(new P (nr, p.ans + "S"));
+                visited[nr] = true;
+            }
+
+            int n4 = n / 1000;
+            nr = (n % 1000) * 10 + n4;
+            if (!visited[nr]) {
+                que.offer(new P (nr, p.ans + "L"));
+                visited[nr] = true;
+            }
+
+            int n1 = n % 10;
+            int nn = n / 10;
+            nr = nn + n1 * 1000;
+            if (!visited[nr]) {
+                que.offer(new P (nr, p.ans + "R"));
+                visited[nr] = true;
+            }
+
+        }
+    }
+}

--- a/그래프 탐색/나영/BOJ_9019_DSLR_2.java
+++ b/그래프 탐색/나영/BOJ_9019_DSLR_2.java
@@ -1,0 +1,92 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int T, x, y;
+    static int prev[];
+    static char charn[];
+    static boolean [] visited;
+    static StringBuilder sb = new StringBuilder();
+    public static void main(String[] args) throws IOException {
+        T = Integer.parseInt(br.readLine());
+
+        for (int t = 0; t < T; t++) {
+            visited = new boolean [10000];
+            prev = new int [10000];
+            charn = new char [10000];
+            st = new StringTokenizer(br.readLine());
+            x = Integer.parseInt(st.nextToken());
+            y = Integer.parseInt(st.nextToken());
+
+            visited[x] = true;
+            prev[x] = -1;
+
+            bfs();
+        }
+        
+        System.out.println(sb.toString());
+    }
+
+    static void bfs() {
+        Queue<Integer> que = new LinkedList<>();
+        que.offer(x);
+
+        while (!que.isEmpty()) {
+            int n = que.poll();
+
+            if (n == y) {
+                sb.append(find(n)).append("\n");
+                return;
+            }
+
+            int nr = n*2 % 10000;
+            if (!visited[nr]) {
+                prev[nr] = n;
+                charn[nr] = 'D';
+                visited[nr] = true;
+                que.offer(nr);
+            }
+
+            nr = n - 1 < 0 ? 9999 : n - 1;
+            if (!visited[nr]) {
+                prev[nr] = n;
+                charn[nr] = 'S';
+                visited[nr] = true;
+                que.offer(nr);
+            }
+
+            int n4 = n / 1000;
+            nr = (n % 1000) * 10 + n4;
+            if (!visited[nr]) {
+                prev[nr] = n;
+                charn[nr] = 'L';
+                visited[nr] = true;
+                que.offer(nr);
+            }
+
+            int n1 = n % 10;
+            int nn = n / 10;
+            nr = nn + n1 * 1000;
+            if (!visited[nr]) {
+                prev[nr] = n;
+                charn[nr] = 'R';
+                visited[nr] = true;
+                que.offer(nr);
+            }
+
+        }
+    }
+
+    static String find(int n) {
+        StringBuilder path = new StringBuilder();
+        while (prev[n] != -1) {
+            path.append(charn[n]);
+            n = prev[n];
+        }
+        
+        return path.reverse().toString();
+    }
+}


### PR DESCRIPTION
### 자료구조
- Queue
- 배열

### 알고리즘
- 그래프 탐색
- BFS

### 시간복잡도
- 두 코드 모두 que에 들어가는 노드 수가 동일하게 10,000까지 간다.
- 내부 연산은 O(1) 수준
- find() 메서드에서 최대 10,000 번까지 이동할 수 있음
- 최종 시간복잡도 : **O(10,000)**

### 배운점
- DSLR 구현이 오히려 더 어려웠던,,
- 처음에는 que에 String 배열을 넣고, DSLR 처리 시 String 값을 Integer로 바꾸거나 char의 위치를 replace 하는 등의 방식으로 구현하려고 했는데, 하다 보니 100% 터질 거 같아서 P 클래스로 바꿨다
- 클래스 P를 통해 이동할 다음 값, 선택한 연산자를 a, ans에 저장한 뒤 que에서 하나씩 꺼내면서 DSLR 연산을 통해 값을 바꿔주고, visited 처리한다.
- 2번째 방법은 역방향 탐색으로 que에는 Integer만 넣어 놓고, DSLR 연산 시 nr이 방문 처리되지 않았다면 prev[nr] 의 값에 n을 넣어 주고 charn[nr]에도 해당 연산자를 넣어 준다.
- 그리고 n == y가 되면 charn[n] 에서부터 역방향 탐색해 연산자를 StringBuilder path에 저장하고, prev[n] = -1, 즉 n 이 x까지 다시 돌아왔을 때 break 하고 path.reverse.toString()을 return해 sb에 append 한다.