### PR TITLE
Solved: [백트래킹] BOJ_순열장난 김나영

### DIFF
--- a/백트래킹/나영/BOJ_10597_순열장난.java
+++ b/백트래킹/나영/BOJ_10597_순열장난.java
@@ -1,0 +1,56 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int arr[];
+    static char charn[];
+    static boolean [] visited = new boolean [51];
+    public static void main(String[] args) throws IOException {
+        charn = br.readLine().toCharArray();
+        arr = new int [charn.length];
+
+        for (int i = 0; i < charn.length; i++) {
+            arr[i] = charn[i] - '0';
+        }
+        
+        dfs(0, new ArrayList<>());
+        
+        System.out.println(sb.toString());
+    }
+
+    static void dfs(int start, List<Integer> list) {
+        if (start == arr.length) {
+            if (!check(list.size())) return;
+            for (int i : list) {
+                System.out.print(i + " ");
+            }
+            System.out.println();
+            System.exit(0);
+        }
+
+        int n = 0;
+
+        for (int i = start; i < arr.length; i++) {
+            n *= 10;
+            n += arr[i];
+
+            if (n > 50 || n == 0) return;
+            if (visited[n]) continue;
+            visited[n] = true;
+            list.add(n);
+            dfs(i+1, list);
+            list.remove(list.size()-1);
+            visited[n] = false;
+        }
+    }
+
+    static boolean check(int size) {
+        for (int i = 1; i <= size; i++) {
+            if(!visited[i]) return false;
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
### 자료구조
- ArrayList
- 배열

### 알고리즘
- 백트래킹
- 조합

### 시간복잡도
- 입력 문자열 길이가 L일 때, 첫 시작점 start에서 다음 값까지 하나씩 추가해가며 50 이하/1 이상인지, 방문 처리되었는지 확인하여 순열을 탐색해 list에 넣는다.
    - 1 2 3이 있으면 1 2 3, 1 23, 12 3 이런 식으로 탐색함
    - 2자리까지만 탐색하므로 한 자리에서 최대 2번의 선택 가능 : 시간복잡도 = O(2^L)
    - check() 메서드의 경우 최대 50까지밖에 안 가므로 상수 처리 가능
- 최악 시간복잡도 : **O(2^L)** 이지만 visited 처리와 1~50 조건으로 거기까지 가진 않음
- 그리고 list.add()와 remove의 경우 끝에서 더하고 삭제하므로 O(n)이 아닌 O(1)의 시간이 걸린다.

### 배운점
- 받은 문자열을 int 배열 arr로 바꾸고, dfs 재귀에서 arr에서 조건에 적합한 조합을 탐색한다.
- 이 때 arr의 이전 인덱스 값을 탐색하면 중복이 발생하므로 start를 재귀에서 넘겨 start ~ arr.length-1 까지 for문을 돌게 하고, 현재 위치의 바로 다음 위치의 값만 n으로 조합해 재귀를 돌려 탐색한다.
- 만약 start가 arr.length까지 왔다면, check() 메서드로 visited 배열이 1~list 길이까지 순서대로 true 체크가 되었는지 확인하고 가능하다면 출력 후 바로 끝낸다.