### PR TITLE
Solved: [백트래킹] BOJ_틱택토 홍지우

### DIFF
--- a/백트래킹/지우/BOJ_7682_틱택토.cpp
+++ b/백트래킹/지우/BOJ_7682_틱택토.cpp
@@ -1,0 +1,66 @@
+#include <iostream>
+#include <vector>
+#include <set>
+
+using namespace std;
+
+vector<int> vis1R; vector<int> vis1C; vector<vector<int>> vis1D;
+vector<int> vis2R; vector<int> vis2C; vector<vector<int>> vis2D;
+set<string> sets;
+string s = ".........";
+
+bool check() {
+    for(int i=0; i<3; i++) {
+        if(vis1R[i] == 3 || vis1C[i] == 3 || vis2R[i] == 3 || vis2C[i] == 3) return true; 
+    }
+    if(vis1D[0][2] == 3 || vis1D[1][2] == 3 || vis2D[0][2] == 3 || vis2D[1][2] == 3) return true;
+    return false;
+}
+
+void dfs(int cnt, char turn) {
+    
+    if(check() || cnt == 9) {
+        sets.insert(s);
+        return;
+    } 
+    if(cnt > 9) return;
+
+
+    for(int i=0; i<9; i++) {
+        if(s[i] != '.') continue;
+
+        int r = i/3; int c = i%3;
+        if(turn == 'X') {
+            vis1R[r]++; vis1C[c]++; vis1D[0][r-c+2]++; vis1D[1][r+c]++;
+            s[i] = 'X';
+            dfs(cnt+1, 'O');
+            vis1R[r]--; vis1C[c]--; vis1D[0][r-c+2]--; vis1D[1][r+c]--;
+            s[i] = '.';
+        }
+        else {
+            vis2R[r]++; vis2C[c]++; vis2D[0][r-c+2]++; vis2D[1][r+c]++;
+            s[i] = 'O';
+            dfs(cnt+1, 'X');
+            vis2R[r]--; vis2C[c]--; vis2D[0][r-c+2]--; vis2D[1][r+c]--;
+            s[i] = '.';
+        }
+        
+    }
+
+}
+
+int main() {
+    cin.tie(0); cout.tie(0); ios::sync_with_stdio(0);
+    vis1R.resize(3,0); vis1C.resize(3,0); vis1D.resize(2, vector<int>(5,0));
+    vis2R.resize(3,0); vis2C.resize(3,0); vis2D.resize(2, vector<int>(5,0));
+    dfs(0, 'X');
+
+    while(1) {
+        string s; cin >> s;
+        if(s == "end") break;
+        if(sets.count(s)) cout << "valid" << "\n";
+        else cout << "invalid" << "\n";
+    }
+    
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터, Set

### 알고리즘
- 백트래킹

### 시간복잡도
- 가능한 모든 틱택토 게임 경우의 수를 백트래킹으로 생성 → 최대 O(9!)
- 각 상태는 문자열로 저장되며 중복 없이 set에 삽입 → O(1) 평균
- 총 시간복잡도는 O(9!) = O(362880), 실질 탐색 수는 약 5천~6천개로 매우 작음

### 배운 점
- 문제를 처음에 잘못 읽어서 앞에서부터 무조건 순서대로 돌을 놓는 줄 알았다.. 하..
- 나영이의 꿀팁! 이 문제가 백트래킹이라는 것을 자각하자.>! 라는 조언에 모든 경우의 수를 모아놓은 후 sets에 넣어 string의 일치 불일치를 판단했다.
- 9개의 칸을 ......... 돌면서 아직 채워지지 않은 칸에 X 차례일 때는 X 가, O 차례일 때는 O가 갈까~ 말까~(원상복구) 하면서 경우의 수를 돈다.
- vis1R[r] : 행의 빙고 / vis1C[c] : 열의 빙고 / vis1D[][] : 2개의 대각선 빙고 사용해서 각 차례가 돌 때마다 누군가의 승리가 정해졌는지 확인했다.
