### PR TITLE
Solved: [백트래킹] BOJ_숌 사이 수열 김나영

### DIFF
--- a/백트래킹/나영/BOJ_1469_숌 사이 수열.java
+++ b/백트래킹/나영/BOJ_1469_숌 사이 수열.java
@@ -1,0 +1,57 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int n;
+    static int [] arr, ex;
+    static boolean [] visited;
+    public static void main(String[] args) throws IOException {
+        n = Integer.parseInt(br.readLine());
+        arr = new int [n];
+        ex = new int [2*n];
+        Arrays.fill(ex, -1);
+        visited = new boolean [n];
+        
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+            if (arr[i] > 2 * n - 2) {
+                System.out.println(-1);
+                return;
+            }
+        }
+
+        Arrays.sort(arr);
+
+        dfs (0);
+        System.out.println(-1);
+    }
+
+    static void dfs(int depth) {
+        if (depth == 2*n) {
+            for (int i : ex) System.out.print(i + " ");
+            System.exit(0);
+            return;
+        }
+
+        if (ex[depth] != -1) {
+            dfs(depth+1);
+            return;
+        }
+
+        for (int i = 0; i < n; i++) {
+            if (visited[i]) continue;
+            int j = depth + arr[i] + 1;
+            if (j < 2*n && ex[j] == -1) {
+                visited[i] = true;
+                ex[depth] = ex[j] = arr[i];
+                dfs(depth+1);
+                ex[depth] = ex[j] = -1;
+                visited[i] = false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
### 자료구조
- 배열

### 알고리즘
- 브루트 포스
- 백트래킹

### 시간복잡도
- n개의 숫자에 대해 2번 선택해 2n 크기의 수열을 탐색해야 함 => nPn => O(n!)
- 하지만 동일한 숫자를 2개만 선택할 수 있고, 배치 조건도 있으므로 가지치기가 됨
- 최악의 경우 : **O(n!)**

### 배운점
- 처음에는 2n까지 모든 수를 dfs를 돌며 뽑으려고 했는데, 그럼 depth의 깊이가 너무 커져서 시간초과 발생
- 그래서 dfs 시 숫자를 하나 선택하면 해당 숫자를 알맞은 위치에 배치시킨 뒤 dfs를 돌렸다
- 이렇게 하면 불가능한 경우의 수도 자동으로 가지치기됨.
- 그리고 **Arrays.sort** 잊지 않기로 해요
- 이거 안 하면 사전 순 정렬 불가