### PR TITLE
Solved: [백트래킹] BOJ_감소하는 수 홍지우

### DIFF
--- a/백트래킹/지우/BOJ_1038_감소하는 수.cpp
+++ b/백트래킹/지우/BOJ_1038_감소하는 수.cpp
@@ -1,0 +1,35 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+vector<long long> desc;
+
+void dfs(int pre, string s_num) {
+    if(s_num != "") {
+        long long num = 0;
+        for(char s : s_num) {
+            num = num * 10 + (s-'0');
+        }
+        desc.push_back(num);
+    }
+
+    for(int i=9; i>=0; i--) {
+        if(pre > i) {
+            dfs(i, s_num + to_string(i));
+        }
+    }
+}
+
+int main() {
+    int N; cin >> N;
+    dfs(10, "");
+    sort(desc.begin(), desc.end());
+
+    if(N >= desc.size()) {
+        cout << -1;
+    } else {
+        cout << desc[N];
+    }
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터, String

### 알고리즘
- 백트래킹

### 시간복잡도 
- 0부터 9까지의 조합 중 감소하는 수만 생성 → 총 경우의 수는 2^10 = 1024개
- 각 수는 생성 후 정렬 → O(1024 log 1024)
- 총 시간복잡도는 O(2^10 + 2^10 log 2^10) = O(1024 log 1024)

### 배운 점
- 이거 저번에 풀었다. N 접근이 desc[N] = 답 <= 이거 빼고는 완전히 동일한듯...?
- 이전 수보다 무조건 작은 수가 다음에 오게끔 dfs(pre, 모인 num) 을 구해 풀었다. ( pre 9-> (8,7,6.5.4.3.2.1.0 가능) )
- 모인 num을 string으로 관리하며 모든 조건을 만족하는 경우의 수를 벡터에 넣는다. (단, long long 형태로)
- sort 해서 인덱스 접근 가능하게끔 한 후, N의 인덱스에 접근해 해당 수를 출력
