### PR TITLE
Solved: [그래프 탐색] BOJ_떡장수와 호랑이 홍지우

### DIFF
--- a/그래프 탐색/지우/BOJ_16432_떡장수와 호랑이.cpp
+++ b/그래프 탐색/지우/BOJ_16432_떡장수와 호랑이.cpp
@@ -1,0 +1,52 @@
+#include <iostream>
+#include <vector>
+
+using namespace std;
+
+int N;
+vector<vector<int>> cakes;
+vector<int> picks;
+vector<vector<int>> memo; // 0: 미계산 / -1: 실패
+
+bool dfs(int day, int pre) { 
+    if(day == N) {
+        return true;
+    }
+
+    if(memo[day][pre] == -1) return false; // 이전에 실패했으면 더 나아가지 않는다.
+    
+    for(int c : cakes[day]) {
+        if(pre != c) {
+            picks.push_back(c);
+            if(dfs(day+1, c)) return true; // 성공했음 탐색 종료
+            picks.pop_back(); // 실패했으면 현재 떡 제거 후 다른 거 시도 
+        }
+    }
+
+    // 여기까지 내려왔다는 것.. 아직 성공하지 못했다는 것..
+    memo[day][pre] = -1;
+    return false;
+
+}
+
+int main() {
+    cin >> N;
+    cakes.resize(N, vector<int>(0));
+    for(int i=0; i<N; i++) {
+        int m; cin >> m;
+        for(int c=0; c<m; c++) {
+            int a; cin >> a;
+            cakes[i].push_back(a);
+        }
+    }
+
+    memo.resize(N+1, vector<int>(10, 0));
+    if(dfs(0, 0)) {
+        for(int p : picks) {
+            cout << p << "\n";
+        }
+    } else {
+        cout << -1;
+    }
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터

### 알고리즘
- 그래프탐색
- DFS + DP

### 시간복잡도
- 각 날마다 최대 9종류의 떡 중에서 이전과 다른 떡을 선택 → O(N * 9)
- 중복 경로를 피하기 위해 메모이제이션 (day, pre) 사용 → 상태 수는 O(N * 10)
- 총 시간복잡도는 O(N * 10) = O(N) 수준 (매우 빠름)

### 배운 점
- memo[][]를 쓰지 않고 그냥 Pre랑 현재만 가능하지 않게 구현했더니 8*1000 <- 시간초과가 났다.
- 모든 불가능한 경우의 수는 깊어지지 않도록 가지치기 해주기 위해 memo[날짜][이전 떡 종류]를 사용했다.
    - dfs 특성상 성공하는 것은 계속 깊어지므로 dfs(다음거) 이후의 코드는 성공하지 않았을 때 돌아가는 코드이다.
    - 그 지점을 활용해 memo[][]에서 해당 날짜에서 이전 날짜에 나눠준 떡이 pre였을 때 -1(실패)를 저장해주고, 이 다음부터 그 어떤 경우의 수도 깊어지지 않게끔 해준 것이다. 
- 또한 return true가 되면 모든 탐색이 삭삭삭 잘리게끔 해줬다.
