### PR TITLE
Solved: [그래프 탐색] BOJ_떡장수와 호랑이 김나영

### DIFF
--- a/그래프 탐색/나영/BOJ_16432_떡장수와 호랑이.java
+++ b/그래프 탐색/나영/BOJ_16432_떡장수와 호랑이.java
@@ -1,0 +1,71 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int n, k;
+    static boolean [][] arr;
+    static boolean [][] visited;
+    static StringBuilder sb = new StringBuilder();
+    public static void main(String[] args) throws IOException {
+        n = Integer.parseInt(br.readLine());
+        arr = new boolean [n][10];
+        visited = new boolean [n][10];
+
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            int rice = Integer.parseInt(st.nextToken());
+            for (int j = 0; j < rice; j++) {
+                int a = Integer.parseInt(st.nextToken());
+                arr[i][a] = true;
+            }
+        }
+
+        if (bfs()) System.out.println(sb.toString());
+        else System.out.println(-1);
+    }
+
+    static class P {
+        int rice, cnt;
+        List<Integer> list;
+
+        P(int rice, int cnt, List<Integer> list) {
+            this.rice = rice;
+            this.cnt = cnt;
+            this.list = list;
+        }
+    }
+
+    static boolean bfs() {
+        Queue<P> que = new LinkedList<>();
+        que.offer(new P (0, 0, new ArrayList<>()));
+
+        while(!que.isEmpty()) {
+            P p = que.poll();
+
+            if (p.cnt == n) {
+                for (int i : p.list) {
+                    sb.append(i).append("\n");
+                }
+                return true;
+            }
+
+            int rice = p.rice;
+
+            if (visited[p.cnt][rice]) continue;
+
+            for (int i = 1; i < 10; i++) {
+                if (arr[p.cnt][i] && rice != i) {
+                    List<Integer> list = new ArrayList<>(p.list);
+                    list.add(i);
+                    visited[p.cnt][rice] = true;
+                    que.offer(new P (i, p.cnt+1, list));
+                }
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
### 자료구조
- Queue
- 배열

### 알고리즘
- 그래프 탐색
- BFS

### 시간복잡도
- n일 동안 10개의 칸 방문 : 10n
- 각 방문 시 for문을 돌며 1~9까지 떡 사용 경로 결정 : 9
- 각 상태에서 리스트 복사 : cnt = n
- 최종 시간복잡도 : O(10n *9 * n) = **O(n^2)**

### 배운점
- 처음에는 visited 배열 없이 진행했는데, 그럼 오백퍼센트 시간초과 각이라 que에서 값을 꺼낼 때 해당 날짜의 해당 떡을 가진 경우가 이미 있었다면 continue 시킨다(어차피 이전 떡만 현재 경로에 영향을 미치므로)
- 그리고 list를 통해 떡을 순서대로 저장했는데, 이렇게 하니까 최악 시간복잡도가 O(n^2)가 나온다. 배열로 바꿀 수 있다면 바꾸는 게 좋을 것 같다.