### PR TITLE
Solved: [백트래킹] BOJ_영재의 시험 홍지우

### DIFF
--- a/백트래킹/지우/BOJ_19949_영재의 시험.cpp
+++ b/백트래킹/지우/BOJ_19949_영재의 시험.cpp
@@ -1,0 +1,40 @@
+#include <iostream>
+#include <vector>
+
+using namespace std;
+
+int ans;
+vector<int> answers;
+
+using namespace std;
+
+void dfs(int pre, int cnt, int depth, int score) {
+    if(depth == 10) {
+        if(score >= 5) ans++;
+        return;
+    }
+    
+    for(int i=1; i<=5; i++) {
+        int tmpScore = score;
+        if(answers[depth] == i) tmpScore++;
+        
+        if(pre!= i) {
+            dfs(i, 1, depth+1, tmpScore);
+        }
+        else if(pre == i && cnt < 2) {
+            dfs(i, 2, depth+1, tmpScore);
+        }
+    }
+}
+
+int main() {
+    cin.tie(0); cout.tie(0); ios::sync_with_stdio(0);
+    answers.resize(10, 0);
+    for(int i=0; i<10; i++) {
+        cin >> answers[i];
+    }
+    
+    dfs(0,0,0,0);
+    cout << ans;
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터

### 알고리즘
- 백트래킹

### 시간복잡도
- 각 문제마다 1~5 중 1개 선택하되, 같은 번호는 3번 이상 연속 불가 → 분기 최대 O(5^10)
- 그러나 연속 제약(최대 2번)으로 실제 분기 수는 훨씬 줄어듦 → 약 O(3^10)
- 총 시간복잡도는 O(3^10) = 약 59000, 완전탐색 가능

### 배운 점
- 각 분기마다 정답인지 아닌지 확인하여 score를 데리고 다니고, 마지막에는 score 값만 비교하게끔 시간복잡도를 줄여줬다.
- depth는 0번 문제부터 9번 문제를 의미한다.
- 각 문제는 1~5의 답을 쓸 수 있다.
    - 만약 answers[depth] == 답(i) 랑 같으면 score은 올라간다. (tmpScore++)
    - 연속된 수인지 아닌지 확인하고 그에 맞게 dfs가 깊어지면 된다.
