### PR TITLE
Solved: [백트래킹] BOJ_텔레포트 3 홍지우

### DIFF
--- a/백트래킹/지우/BOJ_12908_텔레포트 3.cpp
+++ b/백트래킹/지우/BOJ_12908_텔레포트 3.cpp
@@ -1,0 +1,70 @@
+#include <iostream>
+#include <vector>
+#include <climits>
+#include <cmath>
+
+using namespace std;
+
+int sr, sc; int er, ec; 
+long long ans;
+vector<pair<int,int>> ports; // ports[포트Idx] = {r,c}
+vector<int> adj; // adj[포트Idx] = 연결포트Idx
+vector<bool> vis;
+
+int dr[] = {1,0, -1, 0};
+int dc[] = {0, -1, 0, 1};
+
+long long dist(int r, int c, int r1, int c1) {
+    return abs(r-r1) + abs(c-c1);
+}
+
+void dfs(int r, int c, long long time) {
+    if(ans <= time) return;
+    if(r == er && c == ec) {
+        if(ans > time) ans = time;
+        return;
+    }
+
+    // 순수거리 계산 - 중간중간 계속 갱신
+    if(ans > time + dist(r,c, er, ec)) {
+        ans = time + dist(r,c,er,ec);
+    }
+    
+    // 텔레포트
+    for(int i=0; i<6; i++) {
+        if(vis[i]) continue;
+        
+        long long tmpTime = time;
+        auto[pr,pc] = ports[i];
+        auto[nr,nc] = ports[adj[i]];
+
+        tmpTime += dist(r,c,pr,pc) + 10;
+        vis[i] = vis[adj[i]] = true;
+        dfs(nr, nc, tmpTime);
+        vis[i] = vis[adj[i]] = false;
+    }
+}
+
+int main() {
+    cin.tie(0); cout.tie(0); ios::sync_with_stdio(0);
+    cin >> sr >> sc >> er >> ec;
+    ports.resize(6, {0,0});
+    vis.resize(6, false);
+    adj.resize(6,0);
+
+    ans = dist(sr,sc, er,ec);
+
+    int idx = 0;
+    for(int i=0; i<3; i++) {
+        int r1,c1, r2,c2;
+        cin >> r1 >> c1 >> r2 >> c2;
+        
+        ports[idx] = {r1,c1}; ports[idx+1] = {r2,c2};
+        adj[idx] = idx+1; adj[idx+1] = idx;
+        idx+=2;
+    }
+    
+    dfs(sr,sc, 0);
+    cout << ans;
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터

### 알고리즘
- 백트래킹

### 시간복잡도
- 최대 3쌍(6개)의 포탈을 사용할 수 있고, DFS로 포탈 사용 여부를 탐색 → O(6!)
- 각 DFS 호출마다 거리 계산은 O(1)이며, 중복 사용 방지를 위한 백트래킹 적용
- 총 시간복잡도는 O(720) 수준으로 매우 빠르게 동작

### 배운 점
- 어제 푼 진우의 민초우유랑 비슷한 문제이다
- 이동거리를 abs(r-r1) + abs(c-c1)로 풀 수 있다면 대체로 이런 형태의 문제가 된다.
- distance라는 점을 유의해 Long long으로 처리하는 것도 중요 포인트! (나영이가 쏘옥~ 반례 알려줬다)

[Solved]
- 우선 현재까지 가장 작은 Distance는 `dist(시작, 도착)`
- dfs(현재 위치, 시간)
    - 중간 중간 `현재 위치에서 목적지까지의 거리` + `지금까지의 시간`을 더했을 때 ans보다 작아지면 업데이트 해준다. 
        - return 하면 안됨 사실 초기값도 얘가 갱신하지~ -> 뒤 코드 돌려서 텔레포트 이용하면 더 빠를 수도 있으니까!
    - ans보다 큰 time들은 모두 가지치기 해준다.
    - 텔레포드 6 정거장을 모두 돌면서 기존time + 포트까지의 거리 + 10초를 하고 dfs를 돌린다.
    - 이때, 텔레포트 정류장 다녀온 곳은 2 곳 모두 vis 처리를 해줘야 한다.
