### PR TITLE
Solved: [그래프 탐색] BOJ_탈출 김나영

### DIFF
--- a/그래프 탐색/나영/BOJ_3055_탈츨.java
+++ b/그래프 탐색/나영/BOJ_3055_탈츨.java
@@ -1,0 +1,86 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static char [][] map;
+    static int n, m, ans;
+    static int [] dr = {-1, 0, 1, 0};
+    static int [] dc = {0, -1, 0, 1};
+    static Queue<int []> que = new LinkedList<>();
+    static Queue<int []> water = new LinkedList<>();
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+
+        map = new char [n][m];
+
+        for (int r = 0; r < n; r++) {
+            map[r] = br.readLine().toCharArray();
+            for (int c = 0; c < m; c++) {
+                if (map[r][c] == 'S') que.offer(new int [] {r, c, 0});
+                else if (map[r][c] == '*') water.offer(new int [] {r, c});
+            }
+        }
+
+        ans = bfs();
+        
+        System.out.println(ans != -1 ? ans : "KAKTUS");
+    }
+
+    static int bfs() {
+        while (!que.isEmpty()) {
+
+            int size = que.size();
+
+            while(size > 0) {
+                int [] q = que.poll();
+                
+                if (map[q[0]][q[1]] == '*') {
+                    size--;
+                    continue;
+                }
+
+                for (int d = 0; d < 4; d++) {
+                    int nr = q[0] + dr[d];
+                    int nc = q[1] + dc[d];
+
+                    if (check(nr, nc)) {
+                        if (map[nr][nc] == '.') {
+                            map[nr][nc] = 'S';
+                            que.offer(new int [] {nr, nc, q[2] + 1});
+                        } else if (map[nr][nc] == 'D') return q[2] + 1;
+                    }
+                }
+                size--;
+            }
+            
+            int wSize = water.size();
+
+            while (wSize > 0) {
+                int [] w = water.poll();
+
+                for (int d = 0; d < 4; d++) {
+                    int nr = w[0] + dr[d];
+                    int nc = w[1] + dc[d];
+
+                    if (check(nr, nc) && (map[nr][nc] == '.' || map[nr][nc] == 'S')) {
+                        map[nr][nc] = '*';
+                        water.offer(new int [] {nr, nc});
+                    }
+                }
+                wSize--;
+            }
+        }
+
+        return -1;
+    }
+
+    static boolean check(int r, int c) {
+        return r >= 0 && r < n && c >= 0 && c < m;
+    }
+}


### PR DESCRIPTION
### 자료구조
- Queue
- 배열

### 알고리즘
- 그래프 탐색
- BFS

### 시간복잡도
- 불과 고슴도치가 최대 n*m개의 칸을 한 번 방문할 수 있음 : n*m*2 = n*m
- 4방탐색 진행 : 4 (상수이므로 무시)
- 최종 시간복잡도 : **O(nm)**

### 배운점
- 풀었는데 또 틀림,,, 개뽝
- 이 문제의 함정은 **물이 이동할 곳으로 고슴도치가 이동하면 안 된다**는 거였다.
- 그래서 물을 먼저 이동시키고 고슴도치를 이동시킬 때 que에서 꺼낸 고슴도치의 위치 값이 물(*)로 바뀌었다면 continue 처리시켰는데, 오답 발생
- 예외 케이스를 찾아보니, 물이 먼저 이동하고 고슴도치가 이동하는 게 아니라 물과 고슴도치가 **동시에** 이동하고, 이 때 고슴도치가 이동할 다음 칸에 물이 들어오면 이동 불가하다는 것이었다.
- 그래서 고슴도치 que를 먼저 이동시킨 뒤, 물 que를 이동시켜 map의 물 개수를 갱신한다.
- 그 다음 고슴도치 que가 이동할 때, que에서 꺼낸 고슴도치의 위치 값이 물(*)로 바뀌었다면 size-- 하고 continue한다.
- 원래 코드에서 고슴도치를 먼저 이동시키는 식으로만 바꿨습니당