### PR TITLE
Solved: [문자열] BOJ_경고 홍지우

### DIFF
--- a/문자열/지우/BOJ_3029_경고.cpp
+++ b/문자열/지우/BOJ_3029_경고.cpp
@@ -1,0 +1,53 @@
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace std;
+
+vector<int> makeInt(string s) {
+    vector<int> result(3,0);
+    int idx = 0;
+    for(int i=0; i<3; i++) {
+        string tmp = s.substr(idx,2);
+        result[i] = stoi(tmp);
+        idx += 3;
+    }
+    return result;
+}
+
+int main() {
+    vector<int> ans(3,0);
+
+    string curTime;
+    getline(cin, curTime);
+    vector<int> curr = makeInt(curTime);
+    
+    string bombTime;
+    getline(cin, bombTime);
+    vector<int> bomb = makeInt(bombTime);
+
+    if(curTime == bombTime) {
+        cout << "24:00:00";
+        return 0;
+    }
+
+    for(int i=2; i>=0; i--) {
+        if(bomb[i] - curr[i] < 0) {
+            if(i>0) {
+                bomb[i-1]--;
+                ans[i] = bomb[i]+60-curr[i];   
+            } else {
+                ans[i] = bomb[i]+24-curr[i];
+            }
+        } else {
+            ans[i] = bomb[i]-curr[i];
+        }
+    }
+
+    for(int i=0; i<3; i++) {
+        if(ans[i] <=9 ) cout << "0";
+        cout << ans[i];
+        if(i!=2) cout << ":";
+    }
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- String, vector

### 알고리즘
- 문자열

### 시간복잡도
- 문자열 입력은 고정된 길이(8자, HH:MM:SS 형식) → O(1)
- `makeInt()` 함수는 길이 8의 문자열을 세 번 자르고 변환 → O(1)
- 총 연산은 상수 시간 내 수행되므로, 전체 시간복잡도는 O(1)

### 배운 점
- string.substr 활용하여 2칸씩 숫자를 받고, stoi() 사용하여 vector에 숫자형으로 넣어뒀다
- `폭탄 시간 - 현재 시간`을 구할 때 분,초 라면 앞의 수에서 60을 받아올 수 있고, 시라면 다음날이라는 뜻이므로 하늘에서 24가 내려온다. 크크
- 정인이는 적어도 1초를 기다리며, 많아야 24시간을 기다린다. -> 만약 현재 시간과 폭탄 시간이 일치하면 24:00:00를 출력하게끔 했다.