### PR TITLE
Solved: [백트래킹] BOJ_캠프 준비 홍지우

### DIFF
--- a/백트래킹/지우/BOJ_16938_캠프 준비.cpp
+++ b/백트래킹/지우/BOJ_16938_캠프 준비.cpp
@@ -1,0 +1,39 @@
+#include <iostream>
+#include <vector>
+#include <climits>
+
+using namespace std;
+
+int ans;
+int N, L, R, X;
+int INF = INT_MAX;
+vector<int> levels;
+
+void dfs(int s, int cnt, int maxLevel, int minLevel, int sumLevel) {
+    if(cnt >= 2) {
+        if(L <= sumLevel && R >= sumLevel && (maxLevel-minLevel) >= X) {
+            ans++;
+        }
+    }
+    if(s >= N) return;
+    
+    for(int i=s; i<N; i++) {
+        int tmpMax = maxLevel; int tmpMin = minLevel;
+        int currL = levels[i];
+        tmpMax = max(tmpMax, currL); 
+        tmpMin = min(tmpMin, currL);
+        dfs(i+1, cnt+1, tmpMax, tmpMin, sumLevel + currL);
+    }
+}
+
+int main() {
+    cin >> N >> L >> R >> X;
+    levels.resize(N, 0);
+    for(int i=0; i<N; i++) {
+        cin >> levels[i];
+    }
+
+    dfs(0,0,-1,INF,0);
+    cout << ans;
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터

### 알고리즘
- 백트래킹

### 시간복잡도
1. DFS는 모든 문제 조합의 부분집합을 탐색 → **최대 2^N 개의 조합**  
2. 각 조합에서 연산은 상수 시간 (max, min, sum 계산) → **O(1)**  
3. 총 시간복잡도는 **O(2^N)** (N ≤ 15이므로 최대 32,768 → 계산 가능)

### 배운 점
- 모든 부분집합을 구해 조건을 만족하면 cnt를 올려주는 문제였다.
- 현재까지 갖고 있는 max,min 수(중간에 업데이트 되면 안되므로 for문 안에 있어야 함) 새로운 수를 비교하여 min,max 값을 뒤로 넘겨주고
- 현재 위치로부터 무조건 다음 위치부터 끝까지 중에 하나 선택해서 뒤로 넘기는 형식으로 코드를 짰다
- 이 문제도 마찬가지로 조건에 만족한다고 return으로 끝낼 것이 아니라 그 뒤에 더 수가 붙을 수도 있으니 상시적으로 열어두는 If문이 필요했다.
