### PR TITLE
Solved: [그래프 탐색] BOJ_Puyo Puyo 김나영

### DIFF
--- a/그래프 탐색/나영/BOJ_11559_Puyo Puyo.java
+++ b/그래프 탐색/나영/BOJ_11559_Puyo Puyo.java
@@ -1,0 +1,87 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static char [][] map = new char [12][6];
+    static int [] dr = {-1, 0, 1, 0};
+    static int [] dc = {0, -1, 0, 1};
+    static boolean isS;
+    static int cnt;
+    static List<int []> list;
+    static boolean [][] visited;
+    static StringBuilder sb = new StringBuilder();
+    public static void main(String[] args) throws IOException {
+        for (int i = 0; i < 12; i++) {
+            map[i] = br.readLine().toCharArray();
+        }
+
+        while (true) {
+            isS = false;
+            
+            for (int r = 0; r < 12; r++) {
+                for (int c = 0; c < 6; c++) {
+                    if (map[r][c] != '.') bfs(r, c, map[r][c]);
+                }
+            }
+
+            if (isS) cnt++;
+            else break;
+
+            reMap();
+        }
+        
+        System.out.println(cnt);
+    }
+
+    static void reMap() {
+        for (int r = 0; r < 12; r++) {
+            for (int c = 0; c < 6; c++) {
+                if (map[r][c] == '.') {
+                    int nr = r;
+                    while (nr > 0 && map[nr-1][c] != '.') {
+                        map[nr][c] = map[nr-1][c];
+                        nr--;
+                    }
+                    
+                    map[nr][c] = '.';
+                }
+            }
+        }
+    }
+
+    static void bfs(int r, int c, char ch) {
+        Queue<int[]> que = new LinkedList<>();
+        visited = new boolean [12][6];
+        visited[r][c] = true;
+        list = new ArrayList<>();
+        
+        que.offer(new int [] {r, c});
+
+        while (!que.isEmpty()) {
+            int [] q = que.poll();
+            list.add(new int [] {q[0], q[1]});
+
+            for (int d = 0; d < 4; d++) {
+                int nr = q[0] + dr[d];
+                int nc = q[1] + dc[d];
+
+                if (check(nr, nc) && !visited[nr][nc] && map[nr][nc] == ch) {
+                    visited[nr][nc] = true;
+                    que.offer(new int [] {nr, nc});
+                }
+            }
+        }
+
+        if (list.size() >= 4) {
+            isS = true;
+            
+            for (int [] arr : list) map[arr[0]][arr[1]] = '.';
+        }
+    }
+
+    static boolean check(int r, int c) {
+        return r >= 0 && r < 12 && c >= 0 && c < 6;
+    }
+}


### PR DESCRIPTION
### 자료구조
- Queue
- ArrayList
- 배열

### 알고리즘
- 그래프 탐색
- bfs

### 시간복잡도
- BFS : 한 번 돌 때 모든 칸을 최대 한 번만 탐색 : 12 * 6
- reMap : 그래프 탐색 후 map에서 떨어져야 할 뿌요뿌요 위치 변경 : 12 * 6
- 라운드는 최악의 경우 18번까지만 반복됨
    - BFS 한 번은 최대 72칸 탐색 → 한 라운드(전체 탐색)는 O(72 * 72)
    - 연쇄가 일어날 때마다 최소 4개 이상이 터지므로, 최대 연쇄 횟수는 72 / 4 = 18.
- 최종 시간복잡도 : **O((12 * 6) ^ 2 * 18)**

### 배운점
- prev 배열을 통해 풀고 싶었는데 그냥 List 쓰는 게 깔끔할 것 같았다
- bfs로 map을 돌며 동일한 색상이 있는지 확인하고 좌표를 List에 저장
- 이후 List의 크기가 4 이상이라면 하나씩 꺼내서 제거한다
- 전부 제거 후 reMap을 통해 제거된 빈 공간 위에 있는 뿌요뿌요들을 내려줬다
- reMap을 하는 게 좀 힘들었다 헤헷