### PR TITLE
Solved: [문자열] BOJ_그룹 단어 체커 홍지우

### DIFF
--- a/문자열/지우/BOJ_1316_그룹 단어 체커.cpp
+++ b/문자열/지우/BOJ_1316_그룹 단어 체커.cpp
@@ -1,0 +1,33 @@
+#include <iostream>
+#include <string>
+#include <set>
+
+using namespace std;
+
+int main() {
+    int N; cin >> N;
+    int cnt = 0;
+    
+    for(int i=0; i<N; i++) {
+        string s; cin >> s;
+        bool isS = true;
+        set<char> sets;
+        char pre = '\0';
+        
+        for(int i=0; i<s.length(); i++) {
+            if(s[i] != pre && !sets.count(s[i])) {
+                sets.insert(s[i]);
+            }
+            else if(s[i] != pre && sets.count(s[i])) {
+                isS = false;
+                break;
+            }
+
+            pre = s[i];
+        }
+
+        if(isS) cnt++;
+    }
+    cout << cnt;
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- Set, String

### 알고리즘
- 문자열, 구현

### 시간복잡도
1. 문자열 N개에 대해 각각 한 번씩 순회 → O(N)
2. 각 문자열 길이 L에 대해 문자 순회하며 set 연산 수행 → O(L × log 26)
3. 총 시간복잡도는 **O(N × L)** (L은 평균 문자열 길이, 최대 100 정도로 보통 상수 취급 가능)

### 배운 점
- pre와의 비교를 통해 연속 여부를 판단한다.
- pre와 일치하지 않으면 우선 연속된 글자는 아니다.
    - sets에 없던 단어는 그룹 단어의 조건을 헤치지 않는다. 고대~로 sets에 넣어준다.
    - 근데 sets에 있던 단어가 연속되지도 않았으면서 등장~?? : 그룹 단어 놉!