### PR TITLE
Solved: [구현] BOJ_완전 이진 트리 홍지우

### DIFF
--- a/구현/지우/BOJ_9934_완전 이진 트리.cpp
+++ b/구현/지우/BOJ_9934_완전 이진 트리.cpp
@@ -1,0 +1,39 @@
+#include <iostream>
+#include <vector>
+#include <cmath>
+
+using namespace std;
+
+vector<int> arr;
+vector<vector<int>> trees;
+
+void dfs(int depth, int start, int end) {
+    
+    if(start > end) return;
+    int nodeIdx = (start+end)/2;
+    
+    trees[depth].push_back(arr[nodeIdx]);
+
+    dfs(depth+1, start, nodeIdx-1);
+    dfs(depth+1, nodeIdx+1, end);
+}
+
+int main() {
+    int K; cin >> K;
+    int arr_size = pow(2,K) - 1;
+    
+    arr.resize(arr_size, 0); trees.resize(K, vector<int>(0));
+    int node = 0;
+    for(int i=0; i<arr_size; i++) {
+        cin >> arr[i];
+    }
+
+    dfs(0, 0, arr_size-1);
+    for(int d=0; d<K; d++) {
+        for(auto node : trees[d]) {
+            cout << node << " ";
+        }
+        cout << "\n";
+    }
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터

### 알고리즘
- 구현, 분할정복

### 시간복잡도
1. arr의 크기는 2^K - 1 → 노드 개수 N = O(2^K)
2. dfs는 각 노드를 한 번씩 방문하므로 전체 시간복잡도는 O(N)
3. 출력 또한 모든 노드를 순회하므로 전체 시간복잡도는 **O(N)**

### 배운 점
- 얼마만에 보는 분할정복이던가..
- 중위순회를 보는데 주어진 범위에서 딱! 가운데가 늘 루트인 규칙
- depth가 점점 깊어지며 루트를 기준으로 왼쪽, 오른쪽 범위를 나눠서 그 안의 가운데 수를 trees[depth]에 끼워넣으면 된다!
