### PR TITLE
Solved: [구현] BOJ_완전 이진 트리 김나영

### DIFF
--- a/구현/나영/BOJ_9934_완전 이진 트리.java
+++ b/구현/나영/BOJ_9934_완전 이진 트리.java
@@ -1,0 +1,48 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static Scanner sc = new Scanner(System.in);
+    static int k, n, cnt;
+    static int [] arr;
+    static List<Integer> tree [];
+    static StringBuilder sb = new StringBuilder();
+    public static void main(String[] args) {
+        k = sc.nextInt();
+        tree = new ArrayList[k];
+        int tmp = 1;
+        for (int i = 0; i < k; i++) {
+            tree[i] = new ArrayList<>();
+            n += tmp;
+            tmp *= 2;
+        }
+        
+        arr = new int [n];
+        for (int i = 0; i < n; i++) {
+            arr[i] = sc.nextInt();
+        }
+
+        dfs(0, n-1, 0);
+
+        for (int i = 0; i < k; i++) {
+            for (int val : tree[i]) {
+                sb.append(val).append(" ");
+            }
+            sb.append("\n");
+        }
+        System.out.println(sb.toString());
+    }
+
+    static void dfs(int start, int end, int depth) {
+        if (start > end) return;
+        int mid = (start + end) / 2;
+
+        tree[depth].add(arr[mid]);
+
+        // 왼쪽 서브트리
+        dfs(start, mid-1, depth+1);
+        // 오른쪽 서브트리
+        dfs(mid+1, end, depth+1);
+    }
+}


### PR DESCRIPTION
### 자료구조
- ArrayList
- 배열

### 알고리즘
- 구현
- 트리
- 재귀

### 시간복잡도
- 원소의 개수가 n개일 때, n개의 원소를 입력받고 dfs에서 n개의 원소에 최대 한 번 접근함
- 최종 시간복잡도 : **O(n)**

### 배운점
- 규칙을 구현하는 게 참말로 어렵다,,,
- 처음에는 arr의 맨 처음 원소부터 시작해서 접근하려고 했는데, 중간중간 바뀌는 depth를 인지하지 못해 갈아엎음
- 처음에 받은 배열 arr의 끝 길이부터 시작하여, 맨 처음/마지막 원소의 인덱스를 통해 mid 인덱스를 구한다. 이 때 완전이진트리이므로 무조건 해당 tree 중간의 원소는 해당 depth의 루트 원소이다.
- 그래서 tree[depth]에 해당 원소를 넣어준다.
- 그리고 왼쪽/오른쪽 서브트리를 mid-1, mid+1을 통해 차근차근 접근한다.
- 재귀로 이진 트리 접근,,, 한 번 더 풀면 좋을지도