### PR TITLE
Solved: [구현] BOJ_배열 돌리기 2 홍지우

### DIFF
--- a/구현/지우/BOJ_16927_배열 돌리기 2.cpp
+++ b/구현/지우/BOJ_16927_배열 돌리기 2.cpp
@@ -1,0 +1,71 @@
+#include <iostream>
+#include <vector>
+
+using namespace std;
+
+int N, M, R;
+vector<vector<int>> maps;
+
+// 이전걸 끌어오기 
+// 우, 하, 상, 좌
+int dr[] = {0,1,0,-1};
+int dc[] = {1,0,-1,0};
+
+bool inRange(int r , int c, int start) {
+    return r >= start && r< N-start && c>=start && c < M-start;
+}
+
+void move(int start, int total) {
+    int realR = R % total; // 칸 수만큼 이동의 최종 모양은 반복됨!
+    
+    while(realR--) {
+        int r = start; int c = start; // 무조건 이 위치부터 돌릴거임!!
+        int curr = maps[r][c];
+        int d = 0;
+
+        while(d < 4) {
+            int nr = r + dr[d]; int nc = c + dc[d];
+
+            if(nr == r && nc == c) break;
+            if(inRange(nr,nc, start)) {
+                maps[r][c] = maps[nr][nc];
+                r = nr; c = nc;
+            } else {
+                d++;
+            }
+        }
+        maps[start+1][start] = curr;
+    }
+}
+
+int main() {
+    cin >> N >> M >> R;
+    maps.resize(N, vector<int>(M,0));
+
+    for(int r=0; r<N; r++) {
+        for(int c=0; c<M; c++) {
+            cin >> maps[r][c];
+        }
+    }
+
+    int maxDepth = min(M,N)/2; //전체 깊어지는 수
+    int sizeM = M;
+    int sizeN = N;
+
+    for(int d=0; d<maxDepth; d++) {
+        int total = sizeN*2 + sizeM*2 - 4;
+        move(d, total);
+
+        sizeN -= 2;
+        sizeM -= 2;
+    }
+
+    for(int r=0; r<N; r++) {
+        for(int c=0; c<M; c++) {
+            cout << maps[r][c] << " ";
+        }
+        cout << "\n";
+    }
+        
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- 벡터

### 알고리즘
- 구현

### 시간복잡도
1. 회전은 깊이(=layer)마다 수행되며, 총 min(N, M)/2개의 layer가 존재 → O(min(N, M))
2. 각 layer마다 회전할 원소 수는 O(N + M)이며, R회 중 R % 원소수 만큼만 회전 → O(R * (N + M))
3. 전체 시간복잡도는 **O(min(N, M) * R * (N + M))**, 단 R이 충분히 클 경우 O(N * M) 수준으로 수렴

### 배운 점
- 이전 수를 끌어오는 방식으로 dr[], dc[] 를 [우, 하, 상, 좌]로 구성했다

- 깊이(레이어)가 어디까지 가능한지 미리 구하고 각 틀마다 move를 해야 한다.
- 이때 R의 최대값은 해당 틀에 있는 숫자 수만큼까지만 도는게 가능하므로 total을 구해 move에 같이 넘겨준다.

- 최대 돌 수 있는 수는 사실 R%total 만큼이고 - 이만큼 하나씩 이동하며 maps를 다시 채워나간다.
- 틀의 가장 왼쪽 상단의 지점을 start 지점으로 잡고, 하나씩 본인의 이전 칸의 수를 끌어온다. 이때 시작 지점은 사라지므로 미리 저장해둔다.
- d의 방향으로 가다가 범위를 벗어나게 되면 d++로 방향을 바꾼다. 
- 이걸 realR 만큼 반복하면 하나의 틀에 대한 이동은 마무리가 된다.

- 이걸 틀의 수만큼 반복하면 끝!