### PR TITLE
Solved: [완전탐색] PG_피로도 김나영

### DIFF
--- a/완전탐색/나영/PG_피로도.java
+++ b/완전탐색/나영/PG_피로도.java
@@ -1,0 +1,23 @@
+class Solution {
+    static boolean [] vis;
+    static int answer = -1;
+    public int solution(int k, int[][] dungeons) {
+        
+        vis = new boolean [dungeons.length];
+        
+        dfs(k, 0, dungeons);
+        
+        return answer;
+    }
+    
+    static void dfs (int h, int cnt, int [][] dungeons) {
+        answer = Math.max(answer, cnt);
+        
+        for (int i = 0; i < dungeons.length; i++) {
+            if (vis[i] || h < dungeons[i][0]) continue;
+            vis[i] = true;
+            dfs(h-dungeons[i][1], cnt+1, dungeons);
+            vis[i] = false;
+        }
+    }
+}


### PR DESCRIPTION
### 자료구조
- 배열

### 알고리즘
- 완전탐색
- 순열

### 시간복잡도
- n!개의 순열을 탐색
- 최종 시간복잡도 : **O(n!)**

### 배운점
- 순열을 탐색하는 문제
- 이 때, 특정 던전에 접근할 수 있는지 확인하고 가능하면 해당 던전을 돌 때 피로도를 깎아서 dfs로 보내야 한다