### PR TITLE
Solved: [완전탐색] PG_전력망을 둘로 나누기 홍지우

### DIFF
--- a/완전탐색/지우/PG_전력망을 둘로 나누기.cpp
+++ b/완전탐색/지우/PG_전력망을 둘로 나누기.cpp
@@ -1,0 +1,47 @@
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace std;
+vector<int> p;
+
+int find(int a) {
+    if(p[a] == a) {
+        return a;
+    } else {
+        return p[a] = find(p[a]);
+    }
+}
+
+void Union(int a, int b) {
+    a = find(a); 
+    b = find(b);
+    p[b] = a;
+}
+
+int solution(int n, vector<vector<int>> wires) {
+    int answer = n+1;
+    int w = wires.size();
+    
+    for(int i=0; i<w; i++) {
+        p.assign(n+1, 0);
+        for(int a=1; a<=n; a++) {
+            p[a] = a;
+        }
+        
+        for(int k=0; k<w; k++) {
+            if(k==i) continue;
+            int a = wires[k][0]; int b = wires[k][1];
+            Union(a,b);
+        }
+        
+        int p1 = find(p[1]); int cnt1 = 0; int cnt2 =0;
+        for(int a=1; a<=n; a++) {
+            if(find(p[a]) == p1) cnt1++;
+            else cnt2++;
+        }
+        
+        answer = min(answer, abs(cnt1 - cnt2));
+    }
+    return answer;
+}


### PR DESCRIPTION
### 자료구조
- Vector

### 알고리즘
- 완전탐색

### 시간복잡도
- 전선을 하나씩 끊으며 반복하므로 루프는 O(w) (w = wires의 수, 최대 n-1)
- Union-Find로 연결 구성: 각 Union, Find는 평균적으로 O(α(n)) ≈ O(1)
- 전체 복잡도는 O(w × n) → O(n²) (w ≤ n-1)
- (n은 최대 100이므로 최악의 경우 10,000번 돌아서 ㅇㅋ!)

### 배운 점
- union 메서드명 소문자로 적으니까 ambiguous 하다고 떠서 Union 이라고 바꿔줌 (구조체 비슷하게 메모리 공유하는 union 타입, set_union 이런게 있어서 그럼)
- 안녕 유-파 오랜만이야
- 모든 간선 돌면서 끊을 친구 1개 고름
    - 그 간서 제외하고 나머지 간선들을 연결해서 union 시켜줌
    - 이럼 2개의 parent가 존재하게 됨
    - 그 두 Parent의 childs 수를 비교해서 값을 구해줌


- 만약 dfs로 풀면..?
    - 간선 하나 제외하고 인접리스트 만든다
    - 임의의 노드로 시작해 dfs(1) 돌려서 총 cnt 알아낸다. 이러면 다른 집단의 수는 자연스럽게 n-cnt;
    - 이렇게 두 개를 비교해줘도 된다.