### PR TITLE
Solved: [구현] BOJ_배열 돌리기 2 김나영

### DIFF
--- a/구현/나영/BOJ_16927_배열 돌리기 2.java
+++ b/구현/나영/BOJ_16927_배열 돌리기 2.java
@@ -1,0 +1,71 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int N, M, n, m, R;
+    static int [][] map;
+    static int [] dr = {1, 0, -1, 0};
+    static int [] dc = {0, 1, 0, -1};
+    static StringBuilder sb = new StringBuilder();
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        R = Integer.parseInt(st.nextToken());
+
+        map = new int [N][M];
+
+        for (int r = 0; r < N; r++) {
+            st = new StringTokenizer(br.readLine());
+            for (int c = 0; c < M; c++) {
+                map[r][c] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        n = N;
+        m = M;
+
+        for (int i = 0; i < Math.min(N, M) / 2; i++) {
+            find(i, 2 * n + 2 * m - 4);
+            n -= 2;
+            m -= 2;
+        }
+
+        for (int r = 0; r < N; r++) {
+            for (int c = 0; c < M; c++) {
+                sb.append(map[r][c]).append(" ");
+            }
+            sb.append("\n");
+        }
+        
+        System.out.println(sb.toString());
+    }
+
+    static void find (int start, int len) {
+        int size = R % len;
+
+        for (int i = 0; i < size; i++) {
+            int r = start;
+            int c = start;
+            int tmp1 = map[r][c];
+            int tmp2 = 0;
+            int d = 0;
+
+            while (d < 4) {
+                int nr = r + dr[d];
+                int nc = c + dc[d];
+
+                if (nr >= start && nr < N - start && nc >= start && nc < M - start) {
+                    tmp2 = map[nr][nc];
+                    map[nr][nc] = tmp1;
+                    tmp1 = tmp2;
+                    r = nr;
+                    c = nc;
+                } else d++;
+            }
+        }
+    }
+}


### PR DESCRIPTION
### 자료구조
- 배열

### 알고리즘
- 구현

### 시간복잡도
- 최대 회전 수 : R % 전체 테두리 길이(len) 이므로 최대 O(2n + 2m - 4) = O(N + M)
- find 메서드 : 한 회전에 while문을 통해 모든 테두리의 원소를 한 번씩 이동 = O(LEN) = O(N + M)
- find 메서드가 도는 횟수는 테두리 개수 : Math.min(N, M) / 2
- 최종 시간복잡도 : **O(min(N, M) * (N + M) ^ 2)**

### 배운점
- 돌리는 것까진 됐는데 시간복잡도를 줄이는 방법이 고심이었다
- 가장 큰 문제는 R이 10^9까지 간다는 것이므로 입력받은 네모의 테두리 길이를 구한 뒤 **R % len = size**로 해당 회전에서 각 원소가 몇 번째까지 이동할 수 있는지 확인했다. (어차피 아무리 R이 커도 원소의 이동이 계속 반복되는 것이므로 R / 테두리의 나머지 값만 회전시키면 된다. 원소가 얼마나 이동하는지만 확인)
- 그리고 size 번 반복하며 해당 테두리의 모든 원소의 위치를 바꿔 준다.