### PR TITLE
Solved: [그래프 탐색] BOJ_아이템 줍기 홍지우

### DIFF
--- a/그래프 탐색/지우/PG_아이템 줍기2.cpp
+++ b/그래프 탐색/지우/PG_아이템 줍기2.cpp
@@ -1,0 +1,68 @@
+#include <string>
+#include <vector>
+#include <queue>
+
+using namespace std;
+int cX, cY, iX, iY;
+vector<vector<int>> maps(101, vector<int>(101,0));
+vector<vector<int>> dp(101, vector<int>(101,-1));
+queue<pair<int,int>> q;
+
+int dr[] = {-1,0,1,0};
+int dc[] = {0, 1, 0, -1};
+
+bool inRange(int r, int c) {
+    return r>=0 && r<101 && c>=0 && c<101;
+}
+
+int bfs() {
+    dp[cX][cY] = 0;
+    q.push({cX, cY});
+    
+    while(!q.empty()) {
+        auto [r,c] = q.front(); q.pop();
+        if(r==iX && c==iY) {
+            return dp[r][c];
+        }
+        
+        for(int d=0; d<4; d++) {
+            int nr = r + dr[d];
+            int nc = c + dc[d];
+            if(inRange(nr,nc) && maps[nr][nc] == 1 && dp[nr][nc] == -1) {
+                dp[nr][nc] = dp[r][c] + 1;
+                q.push({nr,nc});
+            }
+        }
+    }
+}
+
+int solution(vector<vector<int>> rectangle, int characterX, int characterY, int itemX, int itemY) {
+    int answer = 0;
+    cX = 2 * characterX; cY = 2 * characterY; iX = 2 * itemX; iY = 2 * itemY;
+    
+    // 모두 1로 채워주기
+    for(int i=0; i<rectangle.size(); i++) {
+        int r1 = rectangle[i][0] * 2; int c1 = rectangle[i][1] * 2; 
+        int r2 = rectangle[i][2] * 2; int c2 = rectangle[i][3] * 2;
+        
+        for(int r=r1; r<=r2; r++) {
+            for(int c=c1; c<=c2; c++) {
+                maps[r][c] = 1; 
+            }
+        }
+    }
+    
+    // 테두리 안은 0으로 비워주기
+    for(int i=0; i<rectangle.size(); i++) {
+        int r1 = rectangle[i][0] * 2; int c1 = rectangle[i][1] * 2; 
+        int r2 = rectangle[i][2] * 2; int c2 = rectangle[i][3] * 2;
+        
+        for(int r=r1+1; r<=r2-1; r++) {
+            for(int c=c1+1; c<=c2-1; c++) {
+                maps[r][c] = 0; 
+            }
+        }
+    }
+    
+    return bfs()/2;
+}


### PR DESCRIPTION
### 자료구조
- Vector, Queue

### 알고리즘
- 그래프 탐색
- 에 구현을 곁들인,,

### 시간복잡도
- rectangle의 개수를 R, 각 좌표는 최대 50이므로 맵 크기 최대 100×100 → 사각형 테두리 그리기 O(R × 50²)
- bfs()는 방문하는 격자 수 만큼 수행 → O(N), 여기서 N은 사각형 테두리에 해당하는 칸 수 (최대 약 4000)
- 전체 시간복잡도는 O(R × 2500 + N) → 입력이 작아 충분히 실행 가능한 수준 (R ≤ 10 정도 기준)

### 배운 점
- 저번 PR에도 적었지만 좌표에서는 5 번과 6 번 줄 가운데에도 선이 존재하는데 이걸 *1 상태로만 보면 해당 선을 고려하지 못한다. 따라서 *2를 해줌으로써 (`5`-`6`-`7`) 가운데 선을 다 고려할 수 있게 한다. (`10`11`12`13`14`)
1. *2를 한 상태에서 모든 도형을 전부 다 1로 채운다.
2. 다음에는 모든 도형의 테두리를 제외한 영역을 다 0으로 비운다.
-> 겹친 부분들은 내부가 비워지면서 다 사라진다.
3. Bfs로 최단거리를 찾는다.