### PR TITLE
Solved: [그래프 탐색] PG_아이템 찾기 김나영

### DIFF
--- a/그래프 탐색/나영/PG_아이템 찾기.java
+++ b/그래프 탐색/나영/PG_아이템 찾기.java
@@ -1,0 +1,82 @@
+import java.util.*;
+
+class Solution {
+    static class player
+    {
+        int x;
+        int y;
+        int move;
+        
+        public player(int y, int x, int move)
+        {
+            this.x = x;
+            this.y = y;
+            this.move = move;
+        }
+    }
+    
+    static int[][] map = new int[101][101];
+    static boolean[][] visit = new boolean[101][101];
+    static Queue<player> q;
+    static int[] dx = {-1,1,0,0};
+    static int[] dy = {0,0,-1,1};
+    static int answer = Integer.MAX_VALUE;
+    
+    public int solution(int[][] rectangle, int characterX, int characterY, int itemX, int itemY) {
+        q = new LinkedList<>();
+        q.add(new player(2*characterY, 2*characterX, 0)); //건들지마
+        
+        for(int i = 0 ; i < rectangle.length ; i++)
+        {
+            int lx = rectangle[i][0]*2;
+            int ly = rectangle[i][1]*2;
+            int rx = rectangle[i][2]*2;
+            int ry = rectangle[i][3]*2;
+            
+            for(int j = ry ; j >= ly ; j--)
+            {
+                for(int k = rx ; k >= lx ; k--)
+                {
+                    if(map[j][k] == 2) continue;
+                    
+                    map[j][k] = 2;
+                    
+                    if(j == ly || j == ry || k == lx || k == rx)
+                        map[j][k] = 1;
+                }
+                
+            }
+        }
+                           
+        bfs(2*itemY, 2*itemX);
+        
+        return answer/2;
+    }
+    public static void bfs(int iy, int ix)
+    {
+        while(!q.isEmpty())
+        {
+            player p = q.poll();
+            
+            if(p.y == iy && p.x == ix)
+            {
+                answer = Math.min(answer, p.move);
+                return;
+            }
+            
+            if(visit[p.y][p.x] || map[p.y][p.x] != 1) continue;
+            visit[p.y][p.x] = true;
+            
+            for(int i = 0 ; i < 4 ; i++)
+            {
+                int nx = p.x + dx[i];
+                int ny = p.y + dy[i];
+                
+                if(nx < 0 || ny < 0 || nx > 100 || ny > 100) continue;
+
+                q.add(new player(ny, nx, p.move+1));
+            }
+        }
+    }
+    
+}


### PR DESCRIPTION
### 자료구조
- Queue
- 배열

### 알고리즘
- 그래프 탐색
- BFS

### 시간복잡도
- 사각형을 map에 표시하는 과정: 최악의 경우 rectangle.length * (100*100) → O(n + 100^2) 
- BFS 탐색: 좌표 범위가 최대 100×100이므로 모든 칸을 방문해도 O(100^2) 
- 최종 시간복잡도: O(100^2) = O(1) (상수 범위, 입력 크기 제한 있음) 

### 배운점
- 거지같다
- 이렇게 푸는 방식이 있다고 상상치도 못했다. 죽고싶다.
- 원래 바로 캐릭터를 움직이면서 다른 점과 만나는 지점에서 갈 수 있는지 없는지를 판단하려 했는데 해당 변이 내부에 있는지 판별하기 어려웠다
- 씨름하다 다른 풀이 찾아봤는데 이렇게 풀 수 있구나..
- 각 사각형을 미리 돌며 1과 2를 통해 인접 사각형들의 내부/외부를 판별해준다
- 이 때 두 변이 접하는 경우 내부/외부 판별이 어려워지므로 **좌표 크기를 2배로 해 준다**
- 그리고 아이템을 찾으면 이동 경로 / 2로 값 판별해주기
- 이렇게 푸는 거였구나 하는 문제,,,