### PR TITLE
Solved: [백트래킹] BOJ_도미노 찾기 홍지우

### DIFF
--- a/백트래킹/지우/BOJ_1553_도미노 찾기.cpp
+++ b/백트래킹/지우/BOJ_1553_도미노 찾기.cpp
@@ -1,0 +1,80 @@
+#include <iostream>
+#include <vector>
+#include <set>
+
+using namespace std;
+
+int ans = 0;
+int R = 8; int C = 7;
+vector<vector<int>> maps; 
+vector<vector<bool>> vis;
+vector<int> picks;
+set<pair<int,int>> sets;
+
+int dr[] = {0,1};
+int dc[] = {1,0};
+
+bool inRange(int r, int c) {
+    return r>=0 && r<R && c>=0 && c<C;
+}
+
+void dfs(int depth, int start) {
+    if(depth == 2) {
+        sets.insert({picks[0], picks[1]});
+        sets.insert({picks[1], picks[0]});
+        return;
+    }
+    
+    for(int i=start; i<=6; i++) {
+        picks.push_back(i);
+        dfs(depth+1, i);
+        picks.pop_back();
+    }
+}
+
+void dfs2(int idx, int cnt) {
+
+    if(cnt == 28) {
+        ans++;
+        return;
+    }
+    if(idx >= 8*7) return;
+
+    int r = idx/C; 
+    int c = idx%C;
+    if(vis[r][c]) {
+        dfs2(idx+1, cnt);
+        return; // 밑으로 내려가면 안됨!
+    }
+    for(int d=0; d<2; d++) {
+        int nr = r + dr[d]; int nc = c + dc[d];
+        if(inRange(nr,nc) && !vis[nr][nc]) {
+            int a = maps[r][c]; int b = maps[nr][nc];
+
+            if(sets.count({a,b})) {
+                sets.erase({a,b}); sets.erase({b,a});
+                vis[r][c] = vis[nr][nc] = true;
+                dfs2(idx+1, cnt+1);
+                
+                sets.insert({a, b}); sets.insert({b, a});
+                vis[r][c] = vis[nr][nc] = false;
+            }
+        }
+    }
+}
+
+int main() {
+    maps.resize(R, vector<int>(C,0));
+    vis.resize(R, vector<bool>(C,false));
+    for(int r=0; r<R; r++) {
+        string s; cin >> s;
+        for(int c=0; c<C; c++) {
+            maps[r][c] = s[c]-'0';
+        }
+    }
+
+    dfs(0,0); // 도미노 sets 만들어주기
+    dfs2(0, 0);
+    cout << ans;
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- Set, Vector

### 알고리즘
- 백트래킹, 구현

### 시간복잡도
- dfs()는 도미노 조합 28개를 만들며, 시간복잡도는 상수 O(1) (7개 숫자로 2개 선택하는 조합 → 28개).
- dfs2()는 8×7 격자에서 2칸씩 짝지어 도미노 배치 → 모든 경우의 수 탐색, 최악의 경우 O(2^(56/2)) ≈ O(10⁸)
- 실제 탐색 도중 가지치기(도미노 중복 사용 방지, 방문 여부 확인 등)가 많아, 실행 시간은 충분히 빠름 (완전탐색이지만 효율적 pruning).

### 배운 점
- unordered_set에는 pair를 넣을 수 없다. (오류 뜸) => 그냥 Set 써야 한다.
- dfs()를 `0,0` `0,1` .. 이런 수열의 짝꿍들을 Sets에 넣는다.
- dfs2() 각 자리로부터 오른쪽, 아래를 탐색하며 갖고있는 도미노sets를 쓸 수 있다면 2 자리를 한 번에 vis 처리했다. 
    - 다음 Idx로 넘어갔을 때 이미 vis처리된 자리라면(이전에 좌-우 처리했다면 응당 vis되어 있음) 하나 더 넘어가서 본다.