### PR TITLE
Solved: [그래프 탐색] PG_여행경로 김나영

### DIFF
--- a/그래프 탐색/나영/PG_여행경로.java
+++ b/그래프 탐색/나영/PG_여행경로.java
@@ -1,0 +1,76 @@
+import java.util.Arrays;
+import java.util.List;
+import java.util.ArrayList;
+
+class Solution {
+    static boolean isS;
+    static boolean [] vis;
+    static String [] answer;
+    static String [][] tickets;
+    static List <String> list = new ArrayList<>();
+    public String[] solution(String[][] tickets) {
+        vis = new boolean [tickets.length];
+        this.tickets = tickets;
+        
+        /*
+        Arrays.sort(tickets, new Comparator<String[]> () {
+            @Override
+            public int compare(String [] a, String [] b) {
+                int first = a[0].compareTo(b[0]);
+                
+                if (first == 0) return a[1].compareTo(b[1]);
+                return first;
+            }
+            return 
+        });
+        */
+        
+        /*
+        Arrays.sort(tickets, Comparator
+                    .comparing((String [] a) -> a[0])
+                    .thenComparing(a -> a[1])
+        );
+        */
+        
+        Arrays.sort(tickets, (a, b) -> {
+            int first = a[0].compareTo(b[0]);
+            if (first == 0) return a[1].compareTo(b[1]);
+            return first;
+        });
+        
+        list.add("ICN");
+        
+        for (int i = 0; i < tickets.length; i++) {
+            if (tickets[i][0].equals("ICN")) {
+                vis[i] = true;
+                dfs(i);
+                vis[i] = false;
+                if (isS) break;
+            }
+        }
+        
+        return answer;
+    }
+    
+    static void dfs (int idx) {
+        if (isS) return;
+        if (list.size() == tickets.length) {
+            isS = true;
+            list.add(tickets[idx][1]);
+            answer = list.toArray(new String[0]);
+            return;
+        }
+        
+        for (int i = 0; i < tickets.length; i++) {
+            if (!vis[i] && tickets[idx][1].equals(tickets[i][0])) {
+                vis[i] = true;
+                list.add(tickets[idx][1]);
+                
+                dfs(i);
+                
+                vis[i] = false;
+                list.remove(list.size()-1);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### 자료구조
- ArrayList
- 배열

### 알고리즘
- 그래프 탐색
- DFS

### 시간복잡도
- tickets.length = n이라고 함
- 이론적으로는 모든 티켓의 순열을 탐색할 수도 있으므로 O(n!)임
- 하지만 시작 지점이 ICN인 경우에만 DFS 탐색하고, 만약 모든 공항을 방문한 경로를 찾게 되면 DFS를 종료하므로 n!까지 가지 않음
- 즉, 
    1. 티켓 수(n)가 작음
    2. DFS에서 사전순 정렬 + isS 플래그 덕분에 첫 경로 발견 즉시 종료
- 하기 때문에 **시간복잡도 공식은 여전히 O(n!)**지만, 실제 연산량은 최악보다 훨씬 적다

### 배운점
- 정렬부터 막혔음; 2차원 String 배열 정렬 어떻게 하는지 지금 알았음.
- tickets 배열 정렬하고 list에 미리 "ICN"을 저장한다
- for문을 통해 tickets[i][0] == "ICN" 인 경우 DFS 시~작!
- DFS : 
    - for문을 통해 tickets를 돌며 현재 위치(idx)의 도착 지점이 해당 ticket의 출발지와 동일하다면 방문 처리 + list에 더하고 재귀 탐색한다.
    - 만약 list가 ticket의 길이까지 증가했다면 모든 ticket을 탐색했다는 의미이다. 그러므로 마지막 ticket의 도착지를 list에 add하고,  list를 배열로 바꾼 값을 answer에 저장한다.
    - 그리고 isS = true 처리하고 이후 들어오는 재귀는 막는다
- list.toArray()에 String [] 타입을 지정하지 않으면 Object 배열로 return 되므로 명시해야 한다.