### PR TITLE
Solved: [그래프 탐색] BOJ_미로만들기 김나영

### DIFF
--- a/그래프 탐색/나영/BOJ_2665_미로만들기.java
+++ b/그래프 탐색/나영/BOJ_2665_미로만들기.java
@@ -1,0 +1,59 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static char [][] map;
+    static int [][] vis;
+    static int n, m, ans=Integer.MAX_VALUE;
+    static int [] dr = {-1, 0, 1, 0};
+    static int [] dc = {0, 1, 0, -1};
+    public static void main(String[] args) throws IOException {
+
+        n = Integer.parseInt(br.readLine());
+
+        map = new char [n][];
+
+        for (int r = 0; r < n; r++) {
+            map[r] = br.readLine().toCharArray();
+        }
+
+        m = map[0].length;
+        vis = new int [n][m];
+
+        for (int r = 0; r < n; r++) {
+            Arrays.fill(vis[r], ans);
+        }
+
+        bfs();
+        
+        System.out.println(ans);
+    }
+
+    static void bfs() {
+        Queue<int []> que = new LinkedList<>();
+        que.offer(new int [] {0, 0, 0});
+
+        while (!que.isEmpty()) {
+            int [] q = que.poll();
+
+            if (q[0] == n-1 && q[1] == m-1) ans = Math.min(ans, q[2]);
+
+            for (int d = 0; d < 4; d++) {
+                int nr = q[0] + dr[d];
+                int nc = q[1] + dc[d];
+
+                if (check(nr, nc) && vis[nr][nc] > q[2]) {
+                    vis[nr][nc] = q[2];
+                    if (map[nr][nc] == '0') que.offer(new int [] {nr, nc, q[2]+1});
+                    else que.offer(new int [] {nr, nc, q[2]});
+                }
+            }
+        }
+    }
+
+    static boolean check(int r, int c) {
+        return r >= 0 && r < n && c >= 0 && c < n;
+    }
+}


### PR DESCRIPTION
### 자료구조
- Queue
- 배열

### 알고리즘
- 그래프 탐색
- BFS

### 시간복잡도
- Arrays.fill : O(n * m)
- bfs : 
    - 검은 방에 접근한 경우 q[2]+1 함
    - vis의 값이 q[2]보다 큰 경우만 이동 가능 => 갱신은 값이 감소할 때만 일어나므로 무한 반복 X
    - 시간복잡도 : O(n * m)
- 최종 시간복잡도 : **O(n * m)**

### 배운점
- 기본 bfs에서 vis를 boolean 배열이 아닌 int로 바꿔 풀었다
- q[2]에 바꾼 방의 개수를 저장해서 que에 넣고, 다음 위치로 넘어갈 때 해당 위치의 vis값이 내가 부순 벽의 개수 (q[2]) 보다 큰 경우에만 이동시켰다
- 도착 후 ans에 가장 적게 부순 벽의 개수를 min으로 갱신!