### PR TITLE
Solved: [그래프 탐색] BOJ_미로만들기 홍지우

### DIFF
--- a/그래프 탐색/지우/BOJ_2665_미로만들기.cpp
+++ b/그래프 탐색/지우/BOJ_2665_미로만들기.cpp
@@ -1,0 +1,62 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+#include <tuple>
+
+using namespace std;
+int n;
+int INF = 98765432;
+int ans = INF;
+vector<vector<int>> maps;
+vector<vector<vector<int>>> dp;
+queue<tuple<int,int,int>> q;
+
+int dr[] = {1,0,-1,0};
+int dc[] = {0,-1,0,1};
+
+bool inRange(int r,int c) {
+    return r>=0 && r<n && c>=0 && c<n;
+}
+
+void bfs() {
+    dp[0][0][0] = 0;
+    q.push({0,0,0});
+
+    while(!q.empty()) {
+        auto[r,c,cnt] = q.front(); q.pop();
+        if(r == n-1 && c == n-1) {
+            ans = min(ans, cnt);
+            continue;
+        }
+
+        for(int d=0; d<4; d++) {
+            int nr = r + dr[d]; int nc = c + dc[d];
+            if(!inRange(nr,nc)) continue;
+            if(maps[nr][nc] == 1 && dp[nr][nc][cnt] > dp[r][c][cnt] + 1) {
+                dp[nr][nc][cnt] = dp[r][c][cnt] + 1;
+                q.push({nr,nc, cnt});
+            } else if(maps[nr][nc] == 0 && cnt+1 < n*n && dp[nr][nc][cnt+1] > dp[r][c][cnt] + 1) {
+                dp[nr][nc][cnt+1] = dp[r][c][cnt] + 1;
+                q.push({nr,nc, cnt+1});
+            }
+        }
+    }
+    
+}
+
+int main() {
+    cin >> n;
+    maps.resize(n, vector<int>(n,0));
+    dp.resize(n, vector<vector<int>>(n, vector<int>(n*n, INF)));
+
+    for(int r=0; r<n; r++) {
+        string s; cin >> s;
+        for(int c=0; c<n; c++) {
+            maps[r][c] = s[c]-'0';
+        }
+    }
+
+    bfs();
+    cout << ans;
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- Queue, Vector

### 알고리즘
- 그래프 탐색

### 시간복잡도
1. **BFS 상태 수:**
   각 위치 `(r, c)`에서 벽을 부순 횟수 `cnt`까지 고려 → 총 상태 수는 **O(n × n × n²)** = **O(n³)**
2. **큐에 들어가는 연산:**
   각 상태당 4방향 탐색 (최대 4연산) → **O(4 × n³)** = **O(n³)**
3. **총 시간복잡도:**
   → **O(n³)**
   (`n ≤ 50`인 경우, 최악의 경우 약 125,000 연산으로 충분히 수행 가능)

### 배운 점
시간복잡도에서 아쉬운 풀이였다.
- dp[r][c][부순횟수]가 아니라 `dp[r][c] = 부순횟수`로 갔어야 더 빠르게 돌아간다. (3차원배열이라 n^2 더 돌았다)
- 다른 사람 풀이를 보니까 dequeue를 활용해서 흰 블록이면 dq의 맨 앞 / 검은 블록이면 dq의 맨 뒤로 넣어서 가장 빨리 도달하는 것이 무조건 벽을 부순 횟수의 최소이게끔 풀었다.
- 최단거리가 아닌 최소 벽 부순 횟수를 물어봤으니 좀 더 최적화해서 풀어야 했다!