### PR TITLE
Solved: [그래프 탐색] BOJ_레이저 통신 홍지우

### DIFF
--- a/그래프 탐색/지우/BOJ_6087_레이저 통신.cpp
+++ b/그래프 탐색/지우/BOJ_6087_레이저 통신.cpp
@@ -1,0 +1,74 @@
+#include <iostream>
+#include <vector>
+#include <tuple>
+#include <deque>
+using namespace std;
+
+int C, R;
+int sr, sc, er, ec;
+int INF = 98765432;
+vector<vector<char>> maps;
+vector<vector<vector<int>>> dp;
+deque<tuple<int,int,int,int>> dq;
+
+int dr[] = {1,0,-1,0};
+int dc[] = {0,1,0,-1};
+
+bool inRange(int r, int c) {
+    return r>=0 && r<R && c>=0 && c<C;
+}
+
+int bfs() {
+    for(int d=0; d<4; d++) {
+        dp[sr][sc][d] = 0;
+        dq.push_front({sr,sc,0,d});
+    }
+    while(!dq.empty()) {
+        auto[r,c,cnt,dir] = dq.front(); dq.pop_front();
+        if(r==er && c==ec) {
+            return cnt;
+        }
+        maps[r][c] = cnt+'0';
+
+        for(int d=0; d<4; d++) {
+            if(abs(d-dir)==2) continue;
+
+            int nr = r+dr[d]; int nc = c + dc[d];
+            if(!inRange(nr,nc)) continue;
+            if(maps[nr][nc] == '*') continue;
+
+            if(d==dir && dp[nr][nc][d] > dp[r][c][d]) {
+                dp[nr][nc][d] = dp[r][c][d];
+                dq.push_front({nr,nc,cnt,d});
+            }
+            else if(d!=dir && dp[nr][nc][d] > dp[r][c][dir]+1) {
+                dp[nr][nc][d] = dp[r][c][dir]+1;
+                dq.push_back({nr,nc,cnt+1,d});
+            }
+        }
+    }
+    return -1;
+}
+
+int main() {
+    cin >> C >> R;
+    maps.resize(R, vector<char>(C, '\0'));
+    dp.resize(R, vector<vector<int>>(C, vector<int>(4,INF)));
+    bool first = true;
+    for(int r=0; r<R; r++) {
+        string s; cin >> s;
+        for(int c=0; c<C; c++) {
+            maps[r][c] = s[c];
+            if(maps[r][c] == 'C') {
+                if(first) {
+                    sr = r; sc = c;
+                    first = false;
+                } else {
+                    er = r; ec = c;
+                }
+            }
+        }
+    }
+    cout << bfs();
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- Deque
- Vector

### 알고리즘
- 그래프 탐색

### 시간복잡도
- 각 위치 (r, c)에서 방향 4개에 대해 최소 거울 수를 저장 → dp[r][c][dir] → 총 O(R × C × 4)
- 각 방향에 대해 0-1 BFS (덱을 이용해 최소 거울 개수로 이동) → 각 상태는 한 번만 처리되므로 O(R × C × 4)
- 전체 시간복잡도는 O(R × C), 상수(4)만큼 곱해진 효율적인 탐색 알고리즘입니다.

### 배운 점
- 미로 만들기와 비슷한 문제라고 생각했지만 
- 각각에 들어오는 방향에 따라 설치하는 거울의 수가 달라지므로! (즉, 어떤 방향으로 빛이 들어왔느냐에 따라 거울 설치의 여부가 달라지므로)
    - 같은 지점에 같은 (거울의 수)로 도착해도, 어떤 방향으로 도착했는지에 따라 앞으로의 (거울의 수)가 달라진다!
- 3차원 배열  dp[r][c][해당 칸에서 빛의 방향]!을 활용해야 했다. 