### PR TITLE
Solved: [그래프 탐색] BOJ_거울 설치 홍지우

### DIFF
--- a/그래프 탐색/지우/BOJ_2151_거울 설치.cpp
+++ b/그래프 탐색/지우/BOJ_2151_거울 설치.cpp
@@ -1,0 +1,85 @@
+#include <iostream>
+#include <vector>
+#include <deque>
+#include <tuple>
+
+using namespace std;
+int INF = 98765432;
+int N; int sr,sc, er,ec;
+vector<vector<char>> maps;
+vector<vector<vector<int>>> dp;
+deque<tuple<int,int,int>> dq;
+
+int dr[] = {-1,0,1,0};
+int dc[] = {0,1,0,-1};
+
+bool inRange(int r,int c) {
+    return r>=0 && r<N && c>=0 && c<N;
+}
+
+int bfs() {
+    for(int d=0; d<4; d++) {
+        dp[sr][sc][d] = 0;
+        dq.push_back({sr,sc,d});
+    }
+
+    while(!dq.empty()) {
+        auto[r,c,dir] = dq.front(); dq.pop_front();
+
+        if(r==er && c==ec) {
+            return dp[r][c][dir];
+        }
+
+        if(maps[r][c] == '#' || maps[r][c] == '.') {
+            int nr = r + dr[dir]; int nc = c + dc[dir];
+            if(inRange(nr,nc) && maps[nr][nc] != '*' && dp[nr][nc][dir] > dp[r][c][dir]) {
+                dp[nr][nc][dir] = dp[r][c][dir];
+                dq.push_front({nr,nc,dir});
+            }
+        }
+        else if(maps[r][c] == '!') {
+            
+            for(int d=0; d<4; d++) {
+                if(abs(dir-d) == 2) continue;
+                int nr = r + dr[d]; int nc = c + dc[d];
+                if(!inRange(nr,nc)) continue;
+                if(maps[nr][nc] == '*') continue;
+                
+                if(d == dir && dp[nr][nc][d] > dp[r][c][dir]) {
+                    dp[nr][nc][d] = dp[r][c][dir];
+                    dq.push_front({nr,nc,d});
+                } 
+                else if (d != dir && dp[nr][nc][d] > dp[r][c][dir]+1) {
+                    dp[nr][nc][d] = dp[r][c][dir] + 1;
+                    dq.push_back({nr,nc,d});
+                }
+            }
+        }
+    }
+    return -1;
+}
+
+int main() {
+    cin >> N;
+    maps.resize(N, vector<char>(N,'\0'));
+    dp.resize(N, vector<vector<int>>(N, vector<int>(4,INF)));
+
+    bool first = true;
+    for(int r=0; r<N; r++) {
+        string s; cin >> s;
+        for(int c=0; c<N; c++) {
+            maps[r][c] = s[c];
+            if(maps[r][c] == '#') {
+                if(first){
+                    sr = r; sc = c;
+                    first = false;
+                } else {
+                    er = r; ec = c;
+                }
+            }
+        }
+    }
+    
+    cout << bfs();
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- Deque, Vector

### 알고리즘
- 그래프 탐색

### 시간복잡도
1. BFS는 각 방향(4개)마다 모든 좌표(N×N)에 대해 탐색 → 최대 O(4×N²)
2. 덱을 이용한 0-1 BFS로 거울 설치/비설치 상황을 빠르게 처리
3. 총 시간복잡도는 O(N²), N ≤ 50일 때 최대 약 10,000번 연산으로 충분히 통과

### 배운 점
- 와.. dp[r][c][dir] 을 dp[r][c][d]로 적어서 디버깅을 을매나 한 건지... "제발 처음부터 잘하자 제발"
- 현재 위치 기준으로 #이나 . 에 와있으면 무조건 dir 방향으로만 가고 
- !에 와있으면 현재 각도 + 90도 회전한 방향 2로 갈 수 있게끔 설계했다.
- 덱을 사용해 최소 거울을 사용한 경우가 더 앞에 배치되도록 해줬다.