### PR TITLE
Solved: [그래프 탐색] BOJ_거울 설치 김나영

### DIFF
--- a/그래프 탐색/나영/BOJ_2151_거울 설치.java
+++ b/그래프 탐색/나영/BOJ_2151_거울 설치.java
@@ -1,0 +1,80 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static int [][][] vis;
+    static int n, x, y, ans=Integer.MAX_VALUE;
+    static char [][] map;
+    static int [] dr = {-1, 0, 1, 0};
+    static int [] dc = {0, 1, 0, -1};
+    static Queue<int[]> que = new LinkedList<>();
+    public static void main(String[] args) throws IOException {
+
+        n = Integer.parseInt(br.readLine());
+
+        map = new char [n][n];
+        vis = new int [n][n][4];
+
+        for (int r = 0; r < n; r++) {
+            map[r] = br.readLine().toCharArray();
+            for (int c = 0; c < n; c++) {
+                Arrays.fill(vis[r][c], ans);
+                if (map[r][c] == '#') {
+                    x = r;
+                    y = c;
+                }
+            }
+        }
+
+        for (int d = 0; d < 4; d++) {
+            int nr = x + dr[d];
+            int nc = y + dc[d];
+            vis[x][y][d] = 0;
+
+            if (check(nr, nc) && map[nr][nc] != '*') {
+                que.offer(new int [] {nr, nc, d, 0});
+                vis[nr][nc][d] = 0;
+            }
+        }
+
+        bfs();
+        
+        System.out.print(ans);
+    }
+
+    static void bfs () {
+        while (!que.isEmpty()) {
+            int [] q = que.poll();
+
+            if (map[q[0]][q[1]] == '#') {
+                ans = Math.min(ans, q[3]);
+                continue;
+            }
+            
+            if (map[q[0]][q[1]] == '.') {
+                find(q[0], q[1], q[2], q[3]);
+            } else {
+                for (int d = 0; d < 4; d++) {
+                    if (d == q[2]) find(q[0], q[1], q[2], q[3]);
+                    else find(q[0], q[1], d, q[3] + 1);
+                }
+            }
+        }
+    }
+
+    static void find (int r, int c, int d, int cnt) {
+        int nr = r + dr[d];
+        int nc = c + dc[d];
+
+        if (check(nr, nc) && map[nr][nc] != '*' && vis[nr][nc][d] > cnt) {
+            vis[nr][nc][d] = cnt;
+            que.offer(new int [] {nr, nc, d, cnt});
+        }
+    }
+
+    static boolean check (int r, int c) {
+        return r >= 0 && r < n && c >= 0 && c < n;
+    }
+}


### PR DESCRIPTION
### 자료구조
- Queue
- 배열

### 알고리즘
- 그래프 탐색
- BFS

### 시간복잡도
- 상태 공간은 (r, c, d)로 최대 4 × n² → O(n²)
- bfs : 각 상태는 que에 최대 한 번만 들어감 → O(n²)
- 최종 시간복잡도 : **O(n²)**
- n=50일 때 약 1만 번 연산 → Java에서 0.01~0.05초 이내 실행 가능

### 배운점
- 저번 레이저 탐색과 비슷한데, 이번 문제는 거울을 설치할 수 있는 곳이 있고 없는 곳이 있었다
- 그래서 .일 때는 거울을 사용하지 않으며 방향을 유지하고 이동했고, !일 때는 4방향 탐색하면서 현재 방향과 동일 방향은 거울을 추가하지 않도록 했다
- 그리고 3차원 배열로 각 방향 당 최소 거울의 갯수를 저장하면서 다음 이동 시 이 값보다 더 많은 거울을 사용했다면 que에 넣지 않도록 했다.
- # 칸에 도착하면 que 에 넣지 않도록 했다