### PR TITLE
Solved: [시뮬레이션] BOJ_인내의 도미노 장인 호석 홍지우

### DIFF
--- a/시뮬레이션/지우/BOJ_20165_인내의 도미노 장인 호석.cpp
+++ b/시뮬레이션/지우/BOJ_20165_인내의 도미노 장인 호석.cpp
@@ -1,0 +1,81 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+
+using namespace std;
+int N, M, R; int cnt;
+vector<vector<int>> maps;
+vector<vector<bool>> fallen;
+queue<pair<int,int>> q;
+
+int dr[] = {1,0,-1,0};
+int dc[] = {0,1,0,-1};
+
+bool inRange(int r, int c) {
+    return r>=0 && r<N && c>=0 && c<M;
+}
+
+int EWSN(char dir) {
+    if(dir == 'S') return 0;
+    else if(dir == 'E') return 1;
+    else if(dir == 'N') return 2;
+    return 3;
+}
+
+void bfs(int x, int y, int d) {
+    if(!fallen[x][y]) {
+        fallen[x][y] = true;
+        cnt++;
+        q.push({x,y});
+    }
+
+    while(!q.empty()) {
+        auto[r,c] = q.front(); q.pop();
+
+        int len = maps[r][c];
+        for(int i=0; i<len; i++) {
+            int nr = r + dr[d]*i; int nc = c + dc[d]*i;
+            
+            if(!inRange(nr,nc)) break;
+            if(!fallen[nr][nc]) {
+                fallen[nr][nc] = true;
+                cnt++;
+                q.push({nr,nc});
+            }
+        }
+    }
+}
+
+int main() {
+    cin.tie(0); cout.tie(0); ios::sync_with_stdio(0);
+    cin >> N >> M >> R;
+    maps.resize(N, vector<int>(M, 0));
+    fallen.resize(N, vector<bool>(M, false));
+
+    for(int r=0; r<N; r++) {
+        for(int c=0; c<M; c++) {
+            cin >> maps[r][c];
+        }
+    }
+
+    for(int i=0; i<R; i++) {
+        int r, c; cin >> r >> c; r--; c--;
+        char dir; cin >> dir;
+        int d = EWSN(dir);
+        bfs(r,c,d);
+
+        int x, y; cin >> x >> y; x--; y--;
+        fallen[x][y] = false;
+    }
+
+    cout << cnt << "\n";
+    for(int r=0; r<N; r++) {
+        for(int c=0; c<M; c++) {
+            if(fallen[r][c]) cout << "F ";
+            else cout << "S ";
+        }
+        cout << "\n";
+    }
+    
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- Vector, Queue

### 알고리즘
- 시뮬레이션

### 시간복잡도
- 총 R번의 라운드가 진행되므로, 전체 시간 복잡도는 R × (한 라운드의 복잡도) 입니다.
- 한 번의 공격(bfs)은 최악의 경우 모든 도미노(N*M개)를 쓰러뜨리며, 각 도미노는 자신의 길이(L)만큼 연쇄 반응을 확인합니다.
- 따라서 총 시간 복잡도는 O(R * N * M * L) 이며, 10000 * 100 * 100 * 5는 약 5억이지만, 실제로는 모든 도미노가 최대 길이도 아니고 한번 쓰러지면 다시 확인하지 않으므로 충분히 통과합니다.

### 배운 점
- 1-Based 문제를 0-based 문제로 풀려고 했으면 미리 종이에 1->0!!!! 이렇게 적어놓자.. 또 구현하닥 빼먹어서 디버깅 함..
- 풀이방법: 쓰러트릴 시작점, 방향을 q에 넣어주고 
- -> 만약 이미 쓰러진 경우가 아니라면 본인을 포함해 해당 길이만큼 쓰러트릴 수 있다. 연쇄적으로 쓰러트리면서 아직 안 쓰러트린 애들 cnt 해주며 진행된다.