### PR TITLE
Solved: [투 포인터] BOJ_배열 합치기 홍지우

### DIFF
--- a/투 포인터/지우/BOJ_11728_배열 합치기.cpp
+++ b/투 포인터/지우/BOJ_11728_배열 합치기.cpp
@@ -1,0 +1,40 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+
+int main() {
+    cin.tie(0); cout.tie(0); ios::sync_with_stdio(0);
+    int N; int M; cin >> N >> M;
+
+    vector<int> A(N); 
+    for(int i=0; i<N; i++) {
+        cin >> A[i];
+    }
+    vector<int> B(M);
+    for(int i=0; i<M; i++) {
+        cin >> B[i];
+    }
+
+    int p1 = 0; int p2 = 0;
+    while(p1<N && p2<M) {
+        if(A[p1] <= B[p2]) {
+            cout << A[p1] << " ";
+            p1++;
+        } else {
+            cout << B[p2] << " ";
+            p2++;
+        }
+    }
+
+    while(p1<N) {
+        cout << A[p1] << " ";
+        p1++;
+    }
+    while(p2<M) {
+        cout << B[p2] << " ";
+        p2++;
+    }
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- Vector

### 알고리즘
- 투 포인터

### 시간복잡도
1. 두 배열 A, B를 병합 → 각 원소를 정확히 한 번씩 비교 및 출력  
2. 시간복잡도는 O(N + M) (A와 B의 길이만큼)  
3. 공간복잡도는 O(N + M) (출력만 하고 따로 배열을 안 만들면 O(1) 추가 공간)  

### 배운 점
- 이미 A, B가 정렬된 상태이기 때문에 p1, p2 인덱스를 하나씩 움직이며 A[p1] B[p2] 중 더 작은 값이 먼저 나오도록 한다.
- 한 쪽의 index가 다하면 while 문으로 나머지를 인출해준다. 

---
그냥 모든 Input 을 하나의 배열에 넣고 sort 하면 시간복잡도가 log(N+M) 더 늘어난다
```
int main() {
    vector<int> arr;
    int N; int M; cin >> N >> M;
    int A = N + M;

    arr.resize(A, 0);
    for(int i=0; i<A; i++) {
        cin >> arr[i];
    }

    sort(arr.begin(), arr.end());
    for(int i=0; i<A; i++) {
        cout << arr[i] << " ";
    }
    
    return 0;
}
```
1. 입력 크기 A = N + M개의 원소를 한 번에 정렬  
2. 정렬 알고리즘 시간복잡도는 O(A log A) = O((N + M) log(N + M))  
3. 공간복잡도는 O(A) (입력 배열 저장에 사용)  
