### PR TITLE
Solved: [백트래킹] BOJ_월드컵 김나영

### DIFF
--- a/백트래킹/나영/BOJ_6987_월드컵.java
+++ b/백트래킹/나영/BOJ_6987_월드컵.java
@@ -1,0 +1,73 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static Scanner sc = new Scanner(System.in);
+    static int n, m, total, ans = 1;
+    static int [][] map = new int [6][3];
+    static int[][] match = new int[15][2];
+    static StringBuilder sb = new StringBuilder();
+    public static void main(String[] args) {
+        
+        // 6팀 경기 조합(15개) 미리 계산
+        int idx = 0;
+        for (int i = 0; i < 6; i++) {
+            for (int j = i + 1; j < 6; j++) {
+                match[idx][0] = i;
+                match[idx][1] = j;
+                idx++;
+            }
+        }
+        
+        for (int t = 0; t < 4; t++) {
+            total = 0;
+            for (int i = 0; i < 6; i++) {
+                for (int j = 0; j < 3; j++) {
+                    map[i][j] = sc.nextInt();
+                    total+=map[i][j];
+                }
+            }
+
+            if (total > 30) {
+                sb.append(0 + " ");
+                continue;
+            }
+            
+            if (dfs(0)) sb.append(1 + " ");
+            else sb.append(0 + " ");
+        }
+        
+        System.out.println(sb.toString());
+    }
+
+    static boolean dfs (int tmp) {
+        if (tmp == 15) return true;
+
+        int t1 = match[tmp][0];
+        int t2 = match[tmp][1];
+
+        // t1 승, t2 패
+        if (map[t1][0] > 0 && map[t2][2] > 0) {
+            map[t1][0]--; map[t2][2]--;
+            if (dfs(tmp + 1)) return true;
+            map[t1][0]++; map[t2][2]++;
+        }
+
+        // 무승부
+        if (map[t1][1] > 0 && map[t2][1] > 0) {
+            map[t1][1]--; map[t2][1]--;
+            if (dfs(tmp + 1)) return true;
+            map[t1][1]++; map[t2][1]++;
+        }
+
+        // t1 패, t2 승
+        if (map[t1][2] > 0 && map[t2][0] > 0) {
+            map[t1][2]--; map[t2][0]--;
+            if (dfs(tmp + 1)) return true;
+            map[t1][2]++; map[t2][0]++;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
### 자료구조
- 배열

### 알고리즘
- 브루트포스
- 백트래킹

### 시간복잡도
- 15경기(6팀 조합) 결과를 백트래킹(DFS) 으로 탐색
- 최악 시간복잡도: **O(3^15) ≈ 1.4천만**
    - 하지만 입력 합이 30 초과 시 바로 종료
    - 불가능한 가지는 바로 잘라내기(백트래킹)
    - 가능한 해를 찾으면 즉시 리턴
➡ 실제 실행 시간은 평균적으로 훨씬 빠르며, BOJ 기준 1초 내 통과 가능

### 배운점
- 바보같이 승/무/패 합계 기준으로 풀라다가 예외 왕창 발견하고 후퇴
- 경기 조합이 총 15개이므로, 해당 조합을 미리 배열에 구한 뒤 그 조합을 이용하여 승/무/패 여부를 정한다