### PR TITLE
Solved: [투포인터] BOJ_배열 합치기 김나영

### DIFF
--- a/투 포인터/나영/BOJ_11728_배열 합치기.java
+++ b/투 포인터/나영/BOJ_11728_배열 합치기.java
@@ -1,0 +1,45 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int n, m, p1, p2;
+    static int [] a, b;
+    static StringBuilder sb = new StringBuilder();
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        a = new int [n];
+        b = new int [m];
+        
+        st = new StringTokenizer(br.readLine());
+        
+        for (int i = 0; i < n; i++) {
+            a[i] = Integer.parseInt(st.nextToken());
+        }
+        
+        st = new StringTokenizer(br.readLine());
+
+        for (int i = 0; i < m; i++) {
+            b[i] = Integer.parseInt(st.nextToken());
+        }
+        
+        while(p1 < n && p2 < m) {
+            if (a[p1] < b[p2]) {
+                sb.append(a[p1++] + " ");
+            } else {
+                sb.append(b[p2++] + " ");
+            }
+        }
+
+        if (p1 == n) {
+            while (p2 < m) sb.append(b[p2++] + " ");
+        } else while (p1 < n) sb.append(a[p1++] + " ");
+
+        System.out.println(sb.toString());
+        
+    }
+}


### PR DESCRIPTION
### 자료구조
- 배열

### 알고리즘
- 투포인터

### 시간복잡도
- 두 배열 a, b를 각각 한 번씩만 순회
- while문에서 p1 또는 p2가 매번 증가 → 최대 n+m번 반복
- 남은 원소 복사도 각각 한 번씩만 수행
- 최종 시간복잡도: 𝑂(𝑛+𝑚)

### 배운점
- 투포인터로 안 푸는 게 더 나을듯,,
- 배열을 각각 a, b로 받은 뒤 포인터 p1, p2를 통해 a[p1]와 b[p2] 중 더 큰 값이 있다면 해당 값을 sb에 넣어주고 p1 또는 p2++한다
- 배열 한 쪽을 다 담지 못하는 경우도 있을 수 있으므로 if(p1==n) 을 통해 양쪽 배열의 값이 모두 담길 수 있도록 한다