### PR TITLE
Solved: [그래프 탐색] BOJ_다리 만들기 김나영

### DIFF
--- a/그래프 탐색/나영/BOJ_2146_다리 만들기.java
+++ b/그래프 탐색/나영/BOJ_2146_다리 만들기.java
@@ -1,0 +1,92 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int n, cnt = 2, ans = Integer.MAX_VALUE;
+    static int [][] map, vis;
+    static int [] dr = {-1, 0, 1, 0};
+    static int [] dc = {0, 1, 0, -1};
+    public static void main(String[] args) throws IOException {
+        n = Integer.parseInt(br.readLine());
+        map = new int [n][n];
+        vis = new int [n][n];
+        
+        for (int r = 0; r < n; r++) {
+            st = new StringTokenizer(br.readLine());
+            Arrays.fill(vis[r], Integer.MAX_VALUE);
+            for (int c = 0; c < n; c++) {
+                map[r][c] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        for (int r = 0; r < n; r++) {
+            for (int c = 0; c < n; c++) {
+                if (map[r][c] == 1) {
+                    dfs(r, c);
+                    cnt++;
+                }
+            }
+        }
+
+        for (int r = 0; r < n; r++) {
+            for (int c = 0; c < n; c++) {
+                if (map[r][c] != 0) {
+                    bfs(r, c);
+                }
+            }
+        }
+
+        System.out.println(ans);
+        
+    }
+
+    static void dfs(int r, int c) {
+        map[r][c] = cnt;
+
+        for (int d = 0; d < 4; d++) {
+            int nr = r + dr[d];
+            int nc = c + dc[d];
+
+            if (check(nr, nc) && map[nr][nc] == 1) {
+                dfs(nr, nc);
+            }
+        }
+    }
+
+    static void bfs(int r, int c) {
+        Queue<int[]> que = new LinkedList<>();
+        que.offer(new int [] {r, c});
+        vis[r][c] = 0;
+        int num = map[r][c];
+
+        while (!que.isEmpty()) {
+            int [] q = que.poll();
+
+            for (int d = 0; d < 4; d++) {
+                int nr = q[0] + dr[d];
+                int nc = q[1] + dc[d];
+
+                int next = vis[q[0]][q[1]] + 1;
+    
+                if (check(nr, nc)) {
+                    if (map[nr][nc] != 0 && map[nr][nc] != num) {
+                        ans = Math.min(ans, vis[q[0]][q[1]]);
+                        return;
+                    }
+                    
+                    if (map[nr][nc] == 0 && vis[nr][nc] > next) {
+                        vis[nr][nc] = next;
+                        que.offer(new int [] {nr, nc});
+                    }
+                }
+            }
+        }
+    }
+
+    static boolean check(int r, int c) {
+        return r >= 0 && r < n && c >= 0 && c < n;
+    }
+}


### PR DESCRIPTION
### 자료구조
- Queue
- 배열

### 알고리즘
- 그래프 탐색
- BFS, DFS

### 시간복잡도
- dfs : 한 칸을 최대 한 번만 탐색 ->n^2
- bfs : 
    - 최대 모든 섬의 면적에 대해 한 번 bfs 탐색 : n^2
    - bfs 탐색 시 최대 n^2개의 칸을 돌 수 있음
    - 최악의 경우 n^4 이지만 섬인 경우엔 bfs가 끊기므로 거기까지 가진 않는다
- 최종 시간복잡도 : **O(n^4)**

### 배운점
- dfs로 같은 섬을 숫자로 표시해준다
- 그리고 이중 for 문을 통해 섬을 발견한다면 bfs를 돌려 다른 섬에 닿기까지의 이동 거리를 vis에 저장해준다
    - 이 때, vis에 저장된 값이 현재 이동 값보다 작다면 이동하지 않도록 한다
- 섬의 가장자리만 돌리면 더 빨라질 거 같긴 한데, 어차피 가장자리가 아니면 bfs가 금방 끊기므로 그냥 따로 안 빼고 했다