### PR TITLE
Solved: [그래프 탐색] BOJ_미로 탈출 홍지우

### DIFF
--- a/그래프 탐색/지우/BOJ_14923_미로 탈출.cpp
+++ b/그래프 탐색/지우/BOJ_14923_미로 탈출.cpp
@@ -1,0 +1,65 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+#include <tuple>
+
+using namespace std;
+int ans = -1;
+int N, M; int sr, sc, er, ec;
+int INF = 98765432;
+vector<vector<int>> maps;
+vector<vector<vector<int>>> dp;
+queue<tuple<int,int,int>> q;
+
+int dr[] = {1,0,-1,0};
+int dc[] = {0,1,0,-1};
+
+bool inRange(int r, int c) {
+    return r>=0 && r<N && c>=0 && c<M;
+}
+
+void Bfs() {
+    dp[sr][sc][0] = 0;
+    q.push({sr,sc,0});
+
+    while(!q.empty()) {
+        auto[r, c, wall] = q.front(); q.pop();
+        
+        if(r==er && c==ec) {
+            ans = dp[er][ec][wall];
+            return;
+        }
+
+        for(int d=0; d<4; d++) {
+            int nr = r + dr[d]; int nc = c+dc[d];
+            if(!inRange(nr,nc)) continue;
+            // 벽 부순다!
+            if(maps[nr][nc]==1 && wall == 0 && dp[nr][nc][1] > dp[r][c][0]+1) {
+                dp[nr][nc][1] = dp[r][c][0]+1;
+                q.push({nr,nc,1});
+            }
+            else if(maps[nr][nc]==0 && dp[nr][nc][wall] > dp[r][c][wall]+1){ // 안 부순다!
+                dp[nr][nc][wall] = dp[r][c][wall]+1;
+                q.push({nr,nc,wall});
+            }
+        }
+    }
+}
+  
+int main() {
+    cin >> N >> M;
+    maps.resize(N, vector<int>(M,0));
+    dp.resize(N, vector<vector<int>>(M, vector<int>(2, INF)));
+    cin >> sr >> sc >> er >> ec;
+    sr--; sc--; er--; ec--;
+    for(int r=0; r<N; r++) {
+        for(int c=0; c<M; c++) {
+            cin >> maps[r][c];
+        }
+    }
+
+    Bfs();
+    cout << ans;
+    
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- Queue, Vector

### 알고리즘
- 그래프 탐색

### 시간복잡도
1. BFS 탐색에서 각 칸을 벽을 한 번도 안 부순 상태(0)와 한 번 부순 상태(1)로 나누어 최대 2번 방문 → O(N × M × 2)  
2. 각 칸에서 4방향 탐색 → 총 시간복잡도는 O(4 × N × M) = O(N × M)  
3. 따라서 전체 시간복잡도는 **O(N × M)**이며, N, M ≤ 1,000 정도까지는 충분히 통과 가능  

### 배운 점
- dp[r][c][wall] 로 관리하여 벽을 부순 상태와 안 부순 상태를 따로 나누어 관리했다!
- 벽부수기, 말되원 이런 친구들이랑 비슷한 문제..