### PR TITLE
Solved: [백트래킹] BOJ_미친 로봇 김나영

### DIFF
--- a/백트래킹/나영/BOJ_1405_미친 로봇.java
+++ b/백트래킹/나영/BOJ_1405_미친 로봇.java
@@ -1,0 +1,41 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static Scanner sc = new Scanner(System.in);
+    static int n;
+    static double ans;
+    static double [] arr = new double [4];
+    static int [] dr = {1, -1, 0, 0};
+    static int [] dc = {0, 0, 1, -1};
+    static boolean [][] vis = new boolean [29][29];
+    public static void main(String[] args) {
+        n = sc.nextInt();
+        vis[14][14] = true;
+
+        for (int i = 0; i < 4; i++) arr[i] = sc.nextDouble() / 100;
+
+        dfs(0, 1, 14, 14);
+        
+        System.out.println(ans);
+    }
+
+    static void dfs (int depth, double odds, int r, int c) {
+        if (depth == n) {
+            ans += odds;
+            return;
+        }
+
+        for (int d = 0; d < 4; d++) {
+            int nr = r + dr[d];
+            int nc = c + dc[d];
+
+            if (vis[nr][nc]) continue;
+            vis[nr][nc] = true;
+            double newOdds = odds * arr[d];
+            dfs(depth+1, newOdds, nr, nc);
+            vis[nr][nc] = false;
+        }
+    }
+}


### PR DESCRIPTION
### 자료구조
- 배열

### 알고리즘
- 브루트포스
- 백트래킹

### 시간복잡도
- 각 깊이마다 4분기 선택 가능 -> 깊이 n까지 이동 가능하므로 n^4
- 하지만 vis 체크로 이미 방문한 지점은 가지 않게 해 가지치기
- 최종 시간복잡도 : **O(n^4)** 이지만 가지치기로 거기까지 가진 않음

### 배운점
- dfs로 깊이, 확률, 현재 좌표를 인자로 넘기면서 로봇을 동서남북 이동시키면서 확률을 곱했다
- 다시 생각해보니 확률이 0일 때는 dfs 안 넘어가게 하면 시간이 더 줄어들 듯 하다