### PR TITLE
Solved: [백트래킹] BOJ_스도쿠 김나영

### DIFF
--- a/백트래킹/나영/BOJ_2239_스도쿠.java
+++ b/백트래킹/나영/BOJ_2239_스도쿠.java
@@ -1,0 +1,67 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static int [][] map = new int [9][9];
+    static boolean isS;
+    static boolean [][] R, C;
+    static boolean [][][] rec;
+    static List<int []> list = new ArrayList<>();
+    static StringBuilder sb = new StringBuilder();
+    public static void main(String[] args) throws IOException {
+        R = new boolean [9][10];
+        C = new boolean [9][10];
+        rec = new boolean [3][3][10];
+
+        for (int r = 0; r < 9; r++) {
+            char [] charn = br.readLine().toCharArray();
+            for (int c = 0; c < 9; c++) {
+                map[r][c] = charn[c] - '0';
+                if (map[r][c] == 0) list.add(new int [] {r, c});
+                else {
+                    R[r][map[r][c]] = true;
+                    C[c][map[r][c]] = true;
+                    rec[r/3][c/3][map[r][c]] = true;
+                }
+            }
+        }
+
+        dfs(0);
+        System.out.print(sb.toString());
+    }
+
+    static void dfs (int tmp) {
+        if (isS) return;
+        if (tmp == list.size()) {
+            isS = true;
+            for (int r = 0; r < 9; r++) {
+                for (int c = 0; c < 9; c++) {
+                    System.out.print(map[r][c]);
+                }
+                System.out.println();
+            }
+
+            return;
+        }
+        
+        int r = list.get(tmp)[0];
+        int c = list.get(tmp)[1];
+
+        for (int i = 1; i < 10; i++) {
+            if (R[r][i] || C[c][i] || rec[r/3][c/3][i]) continue;
+            R[r][i] = true;
+            C[c][i] = true;
+            rec[r/3][c/3][i] = true;
+            map[r][c] = i;
+
+            dfs (tmp + 1);
+            
+            R[r][i] = false;
+            C[c][i] = false;
+            rec[r/3][c/3][i] = false;
+            map[r][c] = 0;
+        }
+    }
+}


### PR DESCRIPTION
### 자료구조
- ArrayList
- 배열

### 알고리즘
- 백트래킹

### 시간복잡도
- DFS (백트래킹) : 
    - 빈 칸 개수 = k (최대 81)
    - 각 칸에서 1~9까지 시도 → 최대 9가지 분기
- 따라서 최악의 경우 : **𝑂(9𝑘)**
- 하지만 실제로는 R, C, rec 배열로 가지치기(불가능한 숫자 즉시 skip) →
- 평균 탐색 경우의 수가 크게 줄어듦 (실제 스도쿠는 보통 몇 초 내로 해결 가능)

### 배운점
- 0의 위치를 list에 저장한 뒤 dfs에서 인덱스를 늘려가며 접근한다
-  r, c, 3*3 범위의 boolean 배열을 만든 뒤 map에서 숫자를 받을 때 해당 숫자가 0이 아니라면 각 배열에 방문 처리를 해 준다
- 그리고 dfs 시 사용하고자 하는 숫자가 이미 방문 처리 되었다면 continue 시켰다!