### PR TITLE
Solved: [문자열] BOJ_회문 홍지우

### DIFF
--- a/문자열/지우/BOJ_17609_회문.cpp
+++ b/문자열/지우/BOJ_17609_회문.cpp
@@ -1,0 +1,34 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+
+using namespace std;
+int ans;
+string s;
+
+void dfs(int left, int right, int dCnt) {
+    if(left >= right) {
+        ans = min(ans, dCnt);
+        return;
+    }
+    if(dCnt > 2) return;
+    
+    if(s[left] == s[right]) {
+        dfs(left+1, right-1, dCnt);
+    } else {
+        dfs(left+1, right, dCnt+1);
+        dfs(left, right-1, dCnt+1);
+    }
+}
+
+int main() {
+    cin.tie(0); cout.tie(0); ios::sync_with_stdio(0);
+    int T; cin >> T;
+    while(T--) {
+        cin >> s;
+        ans = 2;
+        dfs(0, s.size()-1, 0);
+        cout << ans << "\n";
+    }
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
- Vector, Queue

### 알고리즘
- 문자열

### 시간복잡도
1. 한 문자열에 대해 최악의 경우 `dfs`는 두 분기로 나뉘며 → 시간복잡도는 O(2^d), 여기서 d는 허용되는 삭제 횟수 (최대 2)
2. 따라서 **문자열 길이 N에 대해 O(N)**의 길이만큼 탐색하며, 분기 깊이가 최대 2라서 전체 탐색은 **상수 수준**의 재귀 호출만 발생
3. 전체 시간복잡도는 **O(T × N)** — T: 테스트케이스 수, N: 문자열 길이

### 배운 점
- 회문 : 양 끝이 서로 같아야 한다. 
- 유사회문: 양 끝 중 하나의 포인터만 옮기면 그 후론 다 같아야 한다.
- 그 외 문자열: 옮기는 횟수가 2개 이상이다!

dfs(왼쪽, 오른쪽, 옮긴 횟수) 를 점점 영역을 좁히며 돌려서
포인터가 서로 마주한 지점에 가장 옮긴 횟수가 작은 걸 => ans
(가지치기: 옮긴 횟수가 2 이상이면 이미 탈락! out!)