### PR TITLE
Solved: [문자열] BOJ_회문 김나영

### DIFF
--- a/문자열/나영/BOJ_17609_회문.java
+++ b/문자열/나영/BOJ_17609_회문.java
@@ -1,0 +1,46 @@
+import java.io.*;
+import java.util.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringBuilder sb = new StringBuilder();
+
+    public static void main(String[] args) throws IOException {
+        int n = Integer.parseInt(br.readLine());
+
+        for (int i = 0; i < n; i++) {
+            char[] ch = br.readLine().toCharArray();
+            sb.append(check(ch)).append("\n");
+        }
+
+        System.out.print(sb.toString());
+    }
+
+    static int check(char[] ch) {
+        int l = 0, r = ch.length - 1;
+
+        while (l < r) {
+            if (ch[l] != ch[r]) {
+                // 한 글자 제거 후 양쪽 검사
+                if (find(ch, l + 1, r) || find(ch, l, r - 1)) {
+                    return 1;
+                } else {
+                    return 2;
+                }
+            }
+            l++;
+            r--;
+        }
+
+        return 0;
+    }
+
+    static boolean find(char[] ch, int l, int r) {
+        while (l < r) {
+            if (ch[l] != ch[r]) return false;
+            l++;
+            r--;
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
### 자료구조
- 배열

### 알고리즘
- 문자열
- 투 포인터

### 시간복잡도
- 테스트 케이스 : n개
- check() : 
    - 왼쪽, 오른쪽 좌표를 이동시키며 문자열 검사 -> m/2 = O(m)
    - find() : 문자열 하나를 제거한 상태에서 탐색해 회문이 가능한지 탐색 -> O(m)
- 최종 시간복잡도 : O(n * m)

### 배운점
- check 메서드에서 문자열 하나를 빼고 계속 while문 돌려서 회문 체크하려고 했는데, 그럼 왼쪽 문자를 빼야 할 지 오른쪽 문자를 빼야 할 지 정확하지 않은 경우 발생
- find 메서드를 이용해 왼쪽/오른쪽 문자를 제거했을 경우 회문이 가능한지 확인 후 알맞은 값 return