### PR TITLE
Solved: [그래프 탐색] BOJ_등수 찾기 홍지우

### DIFF
--- a/그래프 탐색/지우/BOJ_17616_등수 찾기.cpp
+++ b/그래프 탐색/지우/BOJ_17616_등수 찾기.cpp
@@ -1,0 +1,45 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+
+using namespace std;
+int N, M, X;
+
+int bfs(vector<vector<int>>& arr) {
+    queue<int> q; vector<bool> vis(N+1, false);
+    int cnt = -1;
+    vis[X] = true;
+    q.push(X);
+
+    while(!q.empty()) {
+        int curr = q.front(); q.pop();
+        cnt++;
+        for(auto nxt : arr[curr]) {
+            if(!vis[nxt]) {
+                vis[nxt] = true;
+                q.push(nxt);
+            }
+        }
+    }
+
+    return cnt;
+}
+
+int main() {
+    cin.tie(0); cout.tie(0); ios::sync_with_stdio(0);
+    cin >> N >> M >> X;
+    vector<vector<int>> win_lose(N+1, vector<int>(0));
+    vector<vector<int>> lose_win(N+1, vector<int>(0));
+
+    for(int i=0; i<M; i++) {
+        int a, b; cin >> a >> b;
+        win_lose[a].push_back(b);
+        lose_win[b].push_back(a);
+    }
+
+    // 가장 높은 등수 : 나보다 앞선 사람의 수 그 다음 
+    // 가장 낮은 등수 : 나에게 진 사람의 수 그 전
+    cout << bfs(lose_win)+1 << " " << N-bfs(win_lose);
+    
+    return 0;
+}


### PR DESCRIPTION
### 자료구조
 - Vector, Queue

### 알고리즘
- 그래프 탐색

### 시간복잡도
1. 각 BFS 탐색은 한 번의 방문으로 노드들을 큐에 넣고 탐색 → O(N + M)
2. 입력으로 들어오는 간선 정보 M개에 대해 인접 리스트를 구성 → O(M)
3. 전체 시간복잡도는 **O(N + M)** (BFS 2번 호출 포함)

### 배운 점
- 아이디어가 중요한 문제였다.
- 인접리스트 2개를 사용하여 **win_lose[이긴] = {진 리스트}** | **lose_win[진] = {이긴 리스트}** 이렇게 저장한다.
- X 기준으로 그거보다 이긴 사람들 수를 구하면 -> 최대로는 확실히 이긴 리스트 이후엔 바로 이겼다는 뜻
- X 기준으로 그거보다 진 사람들 수를 구하면 -> 최소 이거 보다는 높다는 뜻