### PR TITLE
Solved: [시뮬레이션] BOJ_동방 프로젝트 (Small) 김나영

### DIFF
--- a/시뮬레이션/나영/BOJ_14594_동방 프로젝트 (Small).java
+++ b/시뮬레이션/나영/BOJ_14594_동방 프로젝트 (Small).java
@@ -1,0 +1,33 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int n, m, ans;
+    static boolean [] vis;
+    public static void main(String[] args) throws IOException {
+        n = Integer.parseInt(br.readLine());
+        m = Integer.parseInt(br.readLine());
+
+        vis = new boolean [n+1];
+
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            for (int j = a; j < b; j++) {
+                vis[j] = true;
+            }
+        }
+
+        for (int i = 1; i < n; i++) {
+            if (!vis[i]) ans++;
+        }
+        
+        System.out.println(ans+1);
+    }
+}


### PR DESCRIPTION
### 자료구조
- 배열

### 알고리즘
- 시뮬레이션

### 시간복잡도
- 이중 for문 : m번동안 a~b 사이의 벽을 방문 처리함 -> len_i = b - a 일 때, Σ(len_i) (i=1~m)
- 부수지 않은 벽 개수 세기 : O(n)
- 최종 시간복잡도 : 
<img width="1131" height="104" alt="image" src="https://github.com/user-attachments/assets/205df3bc-35b5-4b09-be7d-b16e4d4030ec" />

### 배운점
- m번의 행동 동안 a~b까지의 벽을 for문을 돌며 방문 처리한다
- 그리고 vis를 통해 0과 n을 제외한 남아있는 벽의 개수를 세면 벽의 개수 + 1이 남은 방의 개수가 된다.