### PR TITLE
Solved: [그리디] BOJ_주유소 김나영

### DIFF
--- a/그리디/나영/BOJ_13305_주유소.java
+++ b/그리디/나영/BOJ_13305_주유소.java
@@ -1,0 +1,29 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int n, idx;
+    static long ans;
+    static int [] oil, dist;
+    public static void main(String[] args) throws IOException {
+        n = Integer.parseInt(br.readLine());
+        dist = new int [n-1];
+        oil = new int [n];
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n-1; i++) dist[i] = Integer.parseInt(st.nextToken());
+        
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) oil[i] = Integer.parseInt(st.nextToken());
+
+        for (int i = 0; i < n-1; i++) {
+            if (oil[idx] > oil[i]) idx = i;
+            ans += (long) oil[idx] * dist[i];
+        }
+        
+        System.out.println(ans);
+    }
+}


### PR DESCRIPTION
### 자료구조
- 배열

### 알고리즘
- 그리디

### 시간복잡도
- 입력 : O(n)
- 비용 계산 : 
    - 0~n-1 개의 거리와 기름값에 대하여 최소 비용 계산 => O(n)
- 최종 시간복잡도 : **O(n)**

### 배운점
- idx를 0부터 시작해서 oil[idx]의 값보다 oil[i]의 값이 더 작은 경우에 idx를 i로 체인지
- 다음 위치로 이동해야 하므로 ans에 oil의 최솟값 * 거리를 더함
- 반드시 **long** 으로 할 것